### PR TITLE
Enforce restricted pod security profile

### DIFF
--- a/apps/ingress-nginx/dev/kustomization.yaml
+++ b/apps/ingress-nginx/dev/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   repo: https://kubernetes.github.io/ingress-nginx
   releaseName: ingress-nginx
   namespace: ingress-nginx
-  version: 4.8.3
+  version: 4.9.0
   additionalValuesFiles:
   - ../base/values.yaml
   - values.yaml

--- a/hack/kind-config/admission-control.yaml
+++ b/hack/kind-config/admission-control.yaml
@@ -6,7 +6,7 @@ plugins:
     apiVersion: pod-security.admission.config.k8s.io/v1
     kind: PodSecurityConfiguration
     defaults:
-      enforce: baseline
+      enforce: restricted
       enforce-version: latest
       audit: restricted
       audit-version: latest

--- a/talconfig.yaml
+++ b/talconfig.yaml
@@ -75,3 +75,20 @@ controlPlane:
     cluster:
       proxy:
         disabled: true
+  - |- # Enforce restricted pod security profile (https://www.talos.dev/latest/kubernetes-guides/configuration/pod-security)
+    - op: replace
+      path: /cluster/apiServer/admissionControl/0/configuration
+      value:
+        apiVersion: pod-security.admission.config.k8s.io/v1
+        kind: PodSecurityConfiguration
+        defaults:
+          enforce: restricted
+          enforce-version: latest
+          audit: restricted
+          audit-version: latest
+          warn: restricted
+          warn-version: latest
+        exemptions:
+          usernames: []
+          runtimeClasses: []
+          namespaces: [kube-system]


### PR DESCRIPTION
This change raises the default level to `restricted` for the pod security admission controller: https://kubernetes.io/docs/concepts/security/pod-security-standards.

This additionally updates the Helm chart for `ingress-nginx` to 4.9.0 which includes appropriate security contexts for its containers.