### PR TITLE
Update ingress-nginx helm chart to 4.9.0

### DIFF
--- a/apps/ingress-nginx/production/kustomization.yaml
+++ b/apps/ingress-nginx/production/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   repo: https://kubernetes.github.io/ingress-nginx
   releaseName: ingress-nginx
   namespace: ingress-nginx
-  version: 4.8.3
+  version: 4.9.0
   additionalValuesFiles:
   - ../base/values.yaml
   - values.yaml


### PR DESCRIPTION
This updates the `ingress-nginx` helm chart to 4.9.0 in production to comply with `restricted` pod security profile change.