### PR TITLE
cilium: Fix DaemonSet patch for production

### DIFF
--- a/system/cilium/production/kustomization.yaml
+++ b/system/cilium/production/kustomization.yaml
@@ -26,6 +26,7 @@ generators:
 
 patches:
 - patch: |-
+    apiVersion: apps/v1
     kind: DaemonSet
     metadata:
       name: cilium


### PR DESCRIPTION
Fixes an omission in the `DaemonSet` patch for production causing the application to not resolve in Argo CD.