### PR TITLE
piraeus/production: Remove existing storage pools/classes

### DIFF
--- a/system/piraeus/production/kustomization.yaml
+++ b/system/piraeus/production/kustomization.yaml
@@ -4,8 +4,6 @@ kind: Kustomization
 resources:
 - ../base
 - talos-loader-overrides.yaml
-- storagepools.yaml
-- storageclasses.yaml
 
 generators:
 - secrets-generator.yaml


### PR DESCRIPTION
Piraeus SED support stage 1. Remove existing Linstor storage pools and storage classes.