### PR TITLE
piraeus: Override piraeus-server image

### DIFF
--- a/system/piraeus/base/config/2_gadgetmg_overrides.yaml
+++ b/system/piraeus/base/config/2_gadgetmg_overrides.yaml
@@ -1,0 +1,9 @@
+---
+base: docker.io/gadgetmg
+components:
+  linstor-controller:
+    tag: v1.25.1
+    image: piraeus-server
+  linstor-satellite:
+    tag: v1.25.1
+    image: piraeus-server

--- a/system/piraeus/base/kustomization.yaml
+++ b/system/piraeus/base/kustomization.yaml
@@ -4,3 +4,10 @@ kind: Kustomization
 resources:
 - https://github.com/piraeusdatastore/piraeus-operator/config/default?ref=v2.3.0
 - cluster.yaml
+
+configMapGenerator:
+- name: piraeus-operator-image-config
+  namespace: piraeus-datastore
+  behavior: merge
+  files:
+  - config/2_gadgetmg_overrides.yaml


### PR DESCRIPTION
Piraeus SED support stage 3. Temporarily override `piraeus-server` image with fork that includes `sedutil-cli`.