### PR TITLE
Revert "piraeus: Override piraeus-server image"

### DIFF
--- a/system/piraeus/base/config/2_gadgetmg_overrides.yaml
+++ b/system/piraeus/base/config/2_gadgetmg_overrides.yaml
@@ -1,9 +1,0 @@
----
-base: docker.io/gadgetmg
-components:
-  linstor-controller:
-    tag: v1.25.1
-    image: piraeus-server
-  linstor-satellite:
-    tag: v1.25.1
-    image: piraeus-server

--- a/system/piraeus/base/kustomization.yaml
+++ b/system/piraeus/base/kustomization.yaml
@@ -4,10 +4,3 @@ kind: Kustomization
 resources:
 - https://github.com/piraeusdatastore/piraeus-operator/config/default?ref=v2.3.0
 - cluster.yaml
-
-configMapGenerator:
-- name: piraeus-operator-image-config
-  namespace: piraeus-datastore
-  behavior: merge
-  files:
-  - config/2_gadgetmg_overrides.yaml


### PR DESCRIPTION
Reverts gadgetmg/home#9. The Samsung SM863a SSD does not support TCG Opal used by `sedutil-cli`.