### PR TITLE
Fix time notation in certificates

### DIFF
--- a/system/piraeus/base/api-ca.yaml
+++ b/system/piraeus/base/api-ca.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   commonName: linstor-api-ca
   secretName: linstor-api-ca
-  duration: 87600h # 10 years
+  duration: 87600h0m0s # 10 years
   isCA: true
   usages:
   - signing

--- a/system/piraeus/base/internal-ca.yaml
+++ b/system/piraeus/base/internal-ca.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   commonName: linstor-internal-ca
   secretName: linstor-internal-ca
-  duration: 87600h # 10 years
+  duration: 87600h0m0s # 10 years
   isCA: true
   usages:
   - signing


### PR DESCRIPTION
Fixes an issue where time notation not being fully correct causes Argo CD to see `piraeus` as out of sync.