### PR TITLE
Extend renovate config for talhelper / Nix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "nix": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "regexManagers": [
+    {
+      "fileMatch": ["^talconfig.yaml$"],
+      "matchStrings": ["talosVersion: [\"']?(?<currentValue>.+?)[\"']?\\s+"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "siderolabs/talos",
+      "extractVersionTemplate": "^(?<version>.*)$"
+    },
+    {
+      "fileMatch": ["^talconfig.yaml$"],
+      "matchStrings": ["kubernetesVersion: [\"']?(?<currentValue>.+?)[\"']?\\s+"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "extractVersionTemplate": "^(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
Adds additional `renovate.json` configuration to enable Nix support along with the Talos and Kubernetes versions set in the `talconfig.yaml` file.