### PR TITLE
ci(renovate): Custom matching from "# renovate:" comments

### DIFF
--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -2,6 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  # renovate: datasource=docker depName=kindest/node
   image: kindest/node:v1.29.0
   kubeadmConfigPatches:
   - |

--- a/renovate.json
+++ b/renovate.json
@@ -9,20 +9,13 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": ["^talconfig.yaml$"],
-      "matchStrings": ["talosVersion: [\"']?(?<currentValue>.+?)[\"']?\\s+"],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "siderolabs/talos",
-      "extractVersionTemplate": "^(?<version>.*)$"
-    },
-    {
-      "fileMatch": ["^talconfig.yaml$"],
-      "matchStrings": ["kubernetesVersion: [\"']?(?<currentValue>.+?)[\"']?\\s+"],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "kubernetes/kubernetes",
-      "extractVersionTemplate": "^(?<version>.*)$"
+      "customType": "regex",
+      "fileMatch": ["\\.yaml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ]
 }

--- a/system/argocd/base/install-ksops.patch.yaml
+++ b/system/argocd/base/install-ksops.patch.yaml
@@ -13,6 +13,7 @@ spec:
           secretName: argocd-sops-age
       initContainers:
       - name: install-ksops
+        # renovate: datasource=docker depName=viaductoss/ksops
         image: viaductoss/ksops:v4.3.1
         securityContext:
           allowPrivilegeEscalation: false

--- a/talconfig.yaml
+++ b/talconfig.yaml
@@ -1,6 +1,8 @@
 ---
 clusterName: talos
+# renovate: datasource=github-releases depName=siderolabs/talos
 talosVersion: v1.6.3
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
 kubernetesVersion: v1.29.1
 endpoint: https://10.1.2.10:6443
 allowSchedulingOnControlPlanes: true


### PR DESCRIPTION
Changes `renovate.json` configuration to include a use a custom matcher for dependencies not automatically discovered via Kustomize, etc.

In `.yaml` files, add a comment formatted like `# renovate: datasource=github-releases depName=kubernetes/kubernetes` before a line with a version and Renovate will capture it.