### PR TITLE
docs(linguist): Make YAML detectable to GItHub's linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yaml linguist-detectable


### PR DESCRIPTION
This change makes YAML detectable to GItHub's linguist to update the list and percentages of languages used in the project.