### PR TITLE
fix(argocd): Ignore "0" resourceFieldRef.divisor

### DIFF
--- a/system/argocd/base/config/resource.customizations.ignoreDifferences.all
+++ b/system/argocd/base/config/resource.customizations.ignoreDifferences.all
@@ -1,0 +1,3 @@
+jqPathExpressions: 
+- .spec.template.spec.containers[].env[].valueFrom.resourceFieldRef | select(.divisor == "0").divisor
+- .spec.template.spec.initContainers[].env[].valueFrom.resourceFieldRef | select(.divisor == "0").divisor

--- a/system/argocd/base/kustomization.yaml
+++ b/system/argocd/base/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
   behavior: merge
   files:
   - config/resource.exclusions
+  - config/resource.customizations.ignoreDifferences.all
   literals:
   - kustomize.buildOptions=--enable-alpha-plugins --enable-exec --enable-helm
 - name: argocd-cmd-params-cm

--- a/system/cilium/dev/kustomization.yaml
+++ b/system/cilium/dev/kustomization.yaml
@@ -20,22 +20,3 @@ helmCharts:
   apiVersions:
   - gateway.networking.k8s.io/v1/GatewayClass
   valuesFile: values.yaml
-
-patches:
-- patch: |-
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      name: cilium
-      namespace: kube-system
-    spec:
-      template:
-        spec:
-          containers:
-          - name: cilium-agent
-            env:
-            - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  divisor: 0
-                  resource: limits.memory

--- a/system/cilium/production/kustomization.yaml
+++ b/system/cilium/production/kustomization.yaml
@@ -23,22 +23,3 @@ helmCharts:
 
 generators:
 - secrets-generator.yaml
-
-patches:
-- patch: |-
-    apiVersion: apps/v1
-    kind: DaemonSet
-    metadata:
-      name: cilium
-      namespace: kube-system
-    spec:
-      template:
-        spec:
-          containers:
-          - name: cilium-agent
-            env:
-            - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  divisor: 0
-                  resource: limits.memory


### PR DESCRIPTION
Fixes an issue with Argo CD which marks a resource as `OutOfSync` if a `resourceFieldRef` has no `divisor` in the desired manifest. Without this, Argo CD will interpret the default value of `"0"` injected by Kubernetes as needing removed.

This also removes cases where a patching workaround was employed to ensure the default `divisor` was in the desired manifest.