### PR TITLE
fix(crossplane): Include CRD

### DIFF
--- a/platform/crossplane/base/kustomization.yaml
+++ b/platform/crossplane/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
 - namespace.yaml
+# CRD for DeploymentRuntimeConfig
+- https://github.com/crossplane/crossplane/raw/v1.14.5/cluster/crds/pkg.crossplane.io_deploymentruntimeconfigs.yaml
 - runtime-config.yaml
 
 helmCharts:


### PR DESCRIPTION
Includes the `DeploymentRuntimeConfig` CRD in the base Kustomization for Crossplane as Argo CD will not resolve without all CRDs immediately available.