### PR TITLE
fix(keycloak): Specify DNS name in certificate

### DIFF
--- a/platform/keycloak/base/keycloak.yaml
+++ b/platform/keycloak/base/keycloak.yaml
@@ -32,6 +32,8 @@ metadata:
 spec:
   secretName: keycloak-tls
   commonName: auth.seigra.net
+  dnsNames:
+  - auth.seigra.net
   issuerRef:
     name: letsencrypt
     kind: ClusterIssuer

--- a/platform/keycloak/dev/patches/hostnames.yaml
+++ b/platform/keycloak/dev/patches/hostnames.yaml
@@ -12,6 +12,8 @@ metadata:
   name: keycloak
 spec:
   commonName: auth.dev.local
+  dnsNames:
+  - auth.dev.local
   issuerRef:
     name: selfsigned
 ---


### PR DESCRIPTION
Includes the DNS name for the Keycloak instance in the `Certificate` as required by the ACME issuer.