### PR TITLE
feat(grafana): Enable SSO for Grafana

### DIFF
--- a/platform/keycloak/base/clients/argocd.yaml
+++ b/platform/keycloak/base/clients/argocd.yaml
@@ -76,16 +76,3 @@ spec:
       name: home
     clientIdRef:
       name: argocd
----
-apiVersion: group.keycloak.crossplane.io/v1alpha1
-kind: Roles
-metadata:
-  name: argocd-admin-group-roles
-spec:
-  forProvider:
-    groupIdRef:
-      name: home-admins
-    realmIdRef:
-      name: home
-    roleIdsRefs:
-    - name: argocd-admin

--- a/platform/keycloak/base/clients/grafana.yaml
+++ b/platform/keycloak/base/clients/grafana.yaml
@@ -1,0 +1,90 @@
+apiVersion: keycloak.crossplane.io/v1alpha1
+kind: StoreConfig
+metadata:
+  name: grafana
+spec:
+  defaultScope: monitoring
+---
+apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+kind: Client
+metadata:
+  name: grafana
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    accessType: CONFIDENTIAL
+    clientId: grafana
+    realmIdRef:
+      name: home
+    standardFlowEnabled: true
+    rootUrl: https://grafana.seigra.net
+    validRedirectUris:
+    - https://grafana.seigra.net/login/generic_oauth
+  publishConnectionDetailsTo:
+    name: grafana-oidc-secret
+    metadata:
+      labels:
+        app.kubernetes.io/part-of: grafana
+    configRef:
+      name: grafana
+---
+apiVersion: client.keycloak.crossplane.io/v1alpha1
+kind: ProtocolMapper
+metadata:
+  name: grafana-roles
+spec:
+  forProvider:
+    config:
+      usermodel.clientRoleMapping.clientId: grafana
+      multivalued: "true"
+      claim.name: roles
+      id.token.claim: "true"
+      access.token.claim: "false"
+      userinfo.token.claim: "false"
+      introspection.token.claim: "false"
+    realmIdRef:
+      name: home
+    clientIdRef:
+      name: grafana
+    name: client roles
+    protocol: openid-connect
+    protocolMapper: oidc-usermodel-client-role-mapper
+---
+apiVersion: role.keycloak.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: grafana-admin
+spec:
+  forProvider:
+    description: Has access to all organization resources, including dashboards, users, and teams.
+    name: admin
+    realmIdRef:
+      name: home
+    clientIdRef:
+      name: grafana
+---
+apiVersion: role.keycloak.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: grafana-editor
+spec:
+  forProvider:
+    description: Can view and edit dashboards, folders, and playlists.
+    name: editor
+    realmIdRef:
+      name: home
+    clientIdRef:
+      name: grafana
+---
+apiVersion: role.keycloak.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: grafana-viewer
+spec:
+  forProvider:
+    description: Can view dashboards, playlists, and query data sources.
+    name: viewer
+    realmIdRef:
+      name: home
+    clientIdRef:
+      name: grafana

--- a/platform/keycloak/base/kustomization.yaml
+++ b/platform/keycloak/base/kustomization.yaml
@@ -36,3 +36,4 @@ resources:
 - crossplane.yaml
 - realms/home.yaml
 - clients/argocd.yaml
+- clients/grafana.yaml

--- a/platform/keycloak/base/realms/home.yaml
+++ b/platform/keycloak/base/realms/home.yaml
@@ -39,3 +39,17 @@ spec:
     name: Guests
     realmIdRef:
       name: home
+---
+apiVersion: group.keycloak.crossplane.io/v1alpha1
+kind: Roles
+metadata:
+  name: admin-group-roles
+spec:
+  forProvider:
+    groupIdRef:
+      name: home-admins
+    realmIdRef:
+      name: home
+    roleIdsRefs:
+    - name: argocd-admin
+    - name: grafana-admin

--- a/platform/keycloak/dev/dev-user.yaml
+++ b/platform/keycloak/dev/dev-user.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   forProvider:
     username: dev
+    email: dev@dev.local
+    emailVerified: true
     initialPassword:
     - valueSecretRef:
         name: keycloak-home-dev-user

--- a/platform/keycloak/dev/patches/hostnames.yaml
+++ b/platform/keycloak/dev/patches/hostnames.yaml
@@ -49,6 +49,16 @@ spec:
     - https://argocd.dev.local/auth/callback
     - https://argocd.dev.local/api/dex/callback
 ---
+apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+kind: Client
+metadata:
+  name: grafana
+spec:
+  forProvider:
+    rootUrl: https://grafana.dev.local
+    validRedirectUris:
+    - https://grafana.dev.local/login/generic_oauth
+---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/kube-prometheus/dev/main.jsonnet
+++ b/platform/kube-prometheus/dev/main.jsonnet
@@ -7,6 +7,19 @@ local kp =
       },
       grafana+: {
         hostname: 'grafana.dev.local',
+        config+: {
+          sections+: {
+            'auth.generic_oauth'+: {
+              auth_url: 'https://auth.dev.local/realms/home/protocol/openid-connect/auth',
+              token_url: 'https://auth.dev.local/realms/home/protocol/openid-connect/token',
+              api_url: 'https://auth.dev.local/realms/home/protocol/openid-connect/userinfo',
+              tls_skip_verify_insecure: true,
+            },
+            server: {
+              root_url: 'https://grafana.dev.local',
+            },
+          },
+        },
       },
       prometheus+: {
         replicas: 1,

--- a/platform/kube-prometheus/lib/grafana-oidc-secret.libsonnet
+++ b/platform/kube-prometheus/lib/grafana-oidc-secret.libsonnet
@@ -1,0 +1,30 @@
+{
+  grafana+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'grafana'
+              then c {
+                env: [
+                  {
+                    name: 'GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET',
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: 'grafana-oidc-secret',
+                        key: 'attribute.client_secret',
+                      },
+                    },
+                  },
+                ],
+              }
+              else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
+}

--- a/platform/kube-prometheus/lib/kube-prometheus.libsonnet
+++ b/platform/kube-prometheus/lib/kube-prometheus.libsonnet
@@ -7,7 +7,8 @@
 (import 'mixins.libsonnet') +  // Additional monitoring mixins (Prometheus alerts + Grafana dashboards)
 (import 'namespace.libsonnet') +  // Patch namespace labels
 (import 'gateway.libsonnet') +  // Gateway resource
-(import 'grafana-httproute.libsonnet') +  // HTTPRoute resource for Graana
+(import 'grafana-httproute.libsonnet') +  // HTTPRoute resource for Grafana
+(import 'grafana-oidc-secret.libsonnet') +  // Configures OIDC client secret for Grafana
 {
   values+:: {
     common+: {
@@ -17,6 +18,33 @@
     },
     grafana+: {
       hostname: error 'must provide hostname for grafana in overlay',
+      config+: {
+        sections+: {
+          auth: {
+            disable_login_form: true,
+          },
+          'auth.generic_oauth': {
+            enabled: true,
+            auto_login: true,
+            name: 'seigra.net',
+            allow_sign_up: true,
+            client_id: 'grafana',
+            scopes: 'openid email profile offline_access roles',
+            email_attribute_path: 'email',
+            login_attribute_path: 'username',
+            name_attribute_path: 'full_name',
+            auth_url: error 'must provide generic OAuth auth_url for grafana in overlay',
+            token_url: error 'must provide generic OAuth token_url for grafana in overlay',
+            api_url: error 'must provide generic OAuth api_url for grafana in overlay',
+            role_attribute_path: "contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || contains(roles[*], 'viewer') && 'Viewer'",
+            role_attribute_strict: true,
+            tls_skip_verify_insecure: true,
+          },
+          server: {
+            root_url: error 'must provide server root URL for grafana in overlay',
+          },
+        },
+      },
     },
     // Requires pod anti-affinity by node
     alertmanager+: {

--- a/platform/kube-prometheus/production/main.jsonnet
+++ b/platform/kube-prometheus/production/main.jsonnet
@@ -7,6 +7,18 @@ local kp =
       },
       grafana+: {
         hostname: 'grafana.seigra.net',
+        config+: {
+          sections+: {
+            'auth.generic_oauth'+: {
+              auth_url: 'https://auth.seigra.net/realms/home/protocol/openid-connect/auth',
+              token_url: 'https://auth.seigra.net/realms/home/protocol/openid-connect/token',
+              api_url: 'https://auth.seigra.net/realms/home/protocol/openid-connect/userinfo',
+            },
+            server: {
+              root_url: 'https://grafana.seigra.net',
+            },
+          },
+        },
       },
     },
   };


### PR DESCRIPTION
This creates a Keycloak client for Grafana and configures Grafana for SSO over OIDC.