### PR TITLE
fix(cilium): Fixes deprecated loadBalancerIP

### DIFF
--- a/system/k8s-gateway/production/kustomization.yaml
+++ b/system/k8s-gateway/production/kustomization.yaml
@@ -7,8 +7,9 @@ resources:
 patches:
 - patch: |- # Explicity set IP to use for the load balancer
     - op: add
-      path: /spec/loadBalancerIP
-      value: 10.1.3.1
+      path: /metadata/annotations
+      value:
+        io.cilium/lb-ipam-ips: 10.1.3.1
   target:
     kind: Service
     name: k8s-gateway


### PR DESCRIPTION
This updates static load balancer IPs to use [proper annotation over the deprecated `loadBalancerIP`](https://docs.cilium.io/en/stable/network/lb-ipam/#requesting-ips).