### PR TITLE
feat(argocd): Separate HA and non-HA configuration

### DIFF
--- a/system/argocd/base/kustomization.yaml
+++ b/system/argocd/base/kustomization.yaml
@@ -3,11 +3,24 @@ kind: Kustomization
 
 namespace: argocd
 
+images:
+- name: quay.io/argoproj/argocd
+  newName: quay.io/argoproj/argocd
+  newTag: v2.10.1
+
 resources:
 - namespace.yaml
-- https://github.com/argoproj/argo-cd/manifests/ha/cluster-install?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/application-controller?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/repo-server?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/server?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/config?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/notification?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/base/applicationset-controller?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/cluster-rbac?ref=v2.10.1
+- https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.10.1
 - gateway.yaml
 - server-httproute.yaml
+- servicemonitors.yaml
 
 configMapGenerator:
 - name: argocd-cm

--- a/system/argocd/base/servicemonitors.yaml
+++ b/system/argocd/base/servicemonitors.yaml
@@ -1,0 +1,75 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-metrics
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-metrics
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-server-metrics
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server-metrics
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-repo-server-metrics
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-repo-server
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-applicationset-controller-metrics
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+  endpoints:
+  - port: metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-redis-haproxy-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-redis-ha-haproxy
+  endpoints:
+  - port: http-exporter-port
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: argocd-notifications-controller
+  labels:
+    release: prometheus-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-notifications-controller-metrics
+  endpoints:
+    - port: metrics

--- a/system/argocd/dev/kustomization.yaml
+++ b/system/argocd/dev/kustomization.yaml
@@ -1,8 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
 - ../base
+- https://github.com/argoproj/argo-cd/manifests/base/redis?ref=v2.10.1
 
 secretGenerator:
 - name: argocd-sops-age
@@ -20,14 +23,6 @@ configMapGenerator:
   literals:
   - oidc.tls.insecure.skip.verify="true"
   - url=https://argocd.dev.local
-
-replicas:
-- name: argocd-redis-ha-haproxy
-  count: 1
-- name: argocd-repo-server
-  count: 1
-- name: argocd-server
-  count: 1
 
 patches:
 - patch: |- # Use self-signed cert for argocd.dev.local in dev

--- a/system/argocd/production/kustomization.yaml
+++ b/system/argocd/production/kustomization.yaml
@@ -1,8 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: argocd
+
 resources:
 - ../base
+- https://github.com/argoproj/argo-cd/manifests/ha/base/redis-ha?ref=v2.10.1
+
+patches:
+- path: https://github.com/argoproj/argo-cd/raw/v2.10.1/manifests/ha/base/overlays/argocd-repo-server-deployment.yaml
+- path: https://github.com/argoproj/argo-cd/raw/v2.10.1/manifests/ha/base/overlays/argocd-server-deployment.yaml
+- path: https://github.com/argoproj/argo-cd/raw/v2.10.1/manifests/ha/base/overlays/argocd-application-controller-statefulset.yaml
+- path: https://github.com/argoproj/argo-cd/raw/v2.10.1/manifests/ha/base/overlays/argocd-cmd-params-cm.yaml
 
 generators:
 - secrets-generator.yaml


### PR DESCRIPTION
This splits the configuration for Argo CD so the dev cluster can use the basic non-HA install without manipulating the redis/haproxy instances. Additionally, this enables ServiceMonitors for Argo CD and disables Dex.