### PR TITLE
feat(ci): Enable renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,19 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true
   },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Enables [Automerge](https://docs.renovatebot.com/key-concepts/automerge/) feature of Renovate for lock file maintenance as well as non-major updates.