### PR TITLE
fix(ci): Bypass renovate automerge checks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
       "automerge": true
     }
   ],
+  "requiredStatusChecks": null,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Disables requirement for status checks to pass during automerges. This is used since the repository currently contains no tests.