### PR TITLE
fix(kp): Update references to Gateway API

### DIFF
--- a/platform/kube-prometheus/lib/gateway.libsonnet
+++ b/platform/kube-prometheus/lib/gateway.libsonnet
@@ -1,4 +1,4 @@
-local gateway_api = import 'github.com/jsonnet-libs/gateway-api-libsonnet/v0.7.1/main.libsonnet';
+local gateway_api = import 'github.com/jsonnet-libs/gateway-api-libsonnet/1.0/main.libsonnet';
 
 {
   kubePrometheus+: {

--- a/platform/kube-prometheus/lib/grafana-httproute.libsonnet
+++ b/platform/kube-prometheus/lib/grafana-httproute.libsonnet
@@ -1,4 +1,4 @@
-local gateway_api = import 'github.com/jsonnet-libs/gateway-api-libsonnet/v0.7.1/main.libsonnet';
+local gateway_api = import 'github.com/jsonnet-libs/gateway-api-libsonnet/1.0/main.libsonnet';
 local k = import 'github.com/jsonnet-libs/k8s-libsonnet/1.28/main.libsonnet';
 
 {


### PR DESCRIPTION
Fixes old locations of Gateway API resources causing `kube-prometheus` to not build.