### PR TITLE
fix(piraeus): Remove /run/udev on docker-based Talos

### DIFF
--- a/system/piraeus/base/talos-loader-overrides.yaml
+++ b/system/piraeus/base/talos-loader-overrides.yaml
@@ -5,35 +5,37 @@ metadata:
 spec:
   patches:
   - target:
-      kind: Pod
-      name: satellite
+      kind: DaemonSet
+      name: linstor-satellite
     patch: |
-      apiVersion: v1
-      kind: Pod
+      apiVersion: apps/v1
+      kind: DaemonSet
       metadata:
-        name: satellite
+        name: linstor-satellite
       spec:
-        initContainers:
-        - name: drbd-shutdown-guard
-          $patch: delete
-        - name: drbd-module-loader
-          $patch: delete
-        volumes:
-        - name: run-systemd-system
-          $patch: delete
-        - name: run-drbd-shutdown-guard
-          $patch: delete
-        - name: systemd-bus-socket
-          $patch: delete
-        - name: lib-modules
-          $patch: delete
-        - name: usr-src
-          $patch: delete
-        - name: etc-lvm-backup
-          hostPath:
-            path: /var/etc/lvm/backup
-            type: DirectoryOrCreate
-        - name: etc-lvm-archive
-          hostPath:
-            path: /var/etc/lvm/archive
-            type: DirectoryOrCreate
+        template:
+          spec:
+            initContainers:
+            - name: drbd-shutdown-guard
+              $patch: delete
+            - name: drbd-module-loader
+              $patch: delete
+            volumes:
+            - name: run-systemd-system
+              $patch: delete
+            - name: run-drbd-shutdown-guard
+              $patch: delete
+            - name: systemd-bus-socket
+              $patch: delete
+            - name: lib-modules
+              $patch: delete
+            - name: usr-src
+              $patch: delete
+            - name: etc-lvm-backup
+              hostPath:
+                path: /var/etc/lvm/backup
+                type: DirectoryOrCreate
+            - name: etc-lvm-archive
+              hostPath:
+                path: /var/etc/lvm/archive
+                type: DirectoryOrCreate

--- a/system/piraeus/dev/kustomization.yaml
+++ b/system/piraeus/dev/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../base
+- talos-docker-overrides.yaml
 
 secretGenerator:
 - name: linstorcluster-passphrase

--- a/system/piraeus/dev/talos-docker-overrides.yaml
+++ b/system/piraeus/dev/talos-docker-overrides.yaml
@@ -1,0 +1,25 @@
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: talos-docker-override
+spec:
+  patches:
+  - target:
+      kind: DaemonSet
+      name: linstor-satellite
+    patch: |
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: linstor-satellite
+      spec:
+        template:
+          spec:
+            containers:
+            - name: linstor-satellite
+              volumeMounts:
+              - mountPath: /run/udev
+                $patch: delete
+            volumes:
+            - name: run-udev
+              $patch: delete


### PR DESCRIPTION
On newer docker-based instances of Talos, `/run/udev` does not exist which causes the default linstor-satellite DaemonSet pods to fail a mount. This is relevant in the context of the "dev" environment or otherwise ephemeral instances of Talos.

This adds an additional patch in the "dev" environment to the linstor-satellite DaemonSet which removes the volume and mount from its pods.