### PR TITLE
chore(deps): Update flake and better document dev script

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1707268954,
-        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
         "type": "github"
       },
       "original": {
@@ -106,11 +106,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1705496572,
-        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "lastModified": 1713537308,
+        "narHash": "sha256-XtTSSIB2DA6tOv+l0FhvfDMiyCmhoRbNB+0SeInZkbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "rev": "5c24cf2f0a12ad855f444c30b2421d044120c66f",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1707504857,
-        "narHash": "sha256-iAYK3Rjm/m+hyfVjMzJRhp5jUi3esWjBfzx1pPE5cwA=",
+        "lastModified": 1713677835,
+        "narHash": "sha256-uORV+CshEELEiX0hOO26RT9UzycOItyr5ZoprS9e3VM=",
         "owner": "budimanjojo",
         "repo": "talhelper",
-        "rev": "605d39d5eab8ad83e669bcdb6db498712554613d",
+        "rev": "b85c2ff54481074541a377f4574c17180b31c3c2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,26 @@
           mv $GOPATH/bin/kustomize-sops $out/bin/ksops
         '';
       });
+      talosctl =
+        let
+          version = "1.7.0";
+          src = pkgs.fetchFromGitHub {
+            owner = "siderolabs";
+            repo = "talos";
+            rev = "v${version}";
+            hash = "sha256-E5pu37R2y0hQezM/p6LJXZv2L6QnV89Ir2HoKaqcOqI=";
+          };
+        in
+        (pkgs.talosctl.override {
+          buildGoModule = args: pkgs.buildGoModule.override { } (args // {
+            inherit src version;
+            vendorHash = "sha256-5vWAZsLQxPZGpTiT/OowCLNPdE5e+HrAGXpFRw6jgbU=";
+          });
+        });
     in
     rec {
-      # Devshell for bootstrapping
-      # Accessible via 'nix develop'
-      devShells.${system} = {
+      # Accessible via 'nix develop' or 'nix shell'
+      packages.${system} = {
         default = pkgs.mkShell {
           NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake";
           nativeBuildInputs = with pkgs; [
@@ -58,9 +73,9 @@
             yq-go
           ];
           shellHook = '' 
-          export PATH="$HOME/.krew/bin:$PATH"
-          krewfile
-        '';
+            export PATH="$HOME/.krew/bin:$PATH"
+            krewfile
+          '';
         };
       };
     };

--- a/hack/dev-cluster.sh
+++ b/hack/dev-cluster.sh
@@ -20,9 +20,13 @@ talosctl gen config dev-talos https://10.5.0.2:6443 \
   --output-types controlplane,talosconfig \
   --output config --force
 # Apply and bootstrap the Talos cluster
-while ! talosctl apply-config --nodes 10.5.0.2 --file config/controlplane.yaml --insecure &> /dev/null; do sleep 1 && echo -n .; done;
-while ! talosctl bootstrap --nodes 10.5.0.2 --endpoints 10.5.0.2 --talosconfig config/talosconfig &> /dev/null; do sleep 1 && echo -n .; done;
-while ! talosctl kubeconfig --nodes 10.5.0.2 --endpoints 10.5.0.2 --talosconfig config/talosconfig &> /dev/null; do sleep 1 && echo -n .; done;
+echo -n "Applying control plane configuration..."
+while ! talosctl apply-config --nodes 10.5.0.2 --file config/controlplane.yaml --insecure &> /dev/null; do sleep 1 && echo -n .; done; echo
+echo -n "Bootstrapping cluster..."
+while ! talosctl bootstrap --nodes 10.5.0.2 --endpoints 10.5.0.2 --talosconfig config/talosconfig &> /dev/null; do sleep 1 && echo -n .; done; echo
+echo -n "Generating kubeconfig..."
+while ! talosctl kubeconfig --nodes 10.5.0.2 --endpoints 10.5.0.2 --talosconfig config/talosconfig &> /dev/null; do sleep 1 && echo -n .; done; echo
+echo -n "Waiting for control plane to be ready..."
 while ! kubectl wait --for=condition=Ready=false node/dev-controlplane-1 --timeout=600s &> /dev/null; do sleep 1 && echo -n .; done; echo
 # Patch CoreDNS configuration to resolve .dev.local domains with k8s_gateway
 kubectl apply -f local-dns.yaml

--- a/hack/docker-compose.yaml
+++ b/hack/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/siderolabs/talos:v1.6.7
     environment:
       PLATFORM: container
+      TALOSSKU: 12CPU-16384RAM
     read_only: true
     privileged: true
     security_opt:


### PR DESCRIPTION
- Updates the flake to more current packages
- Adds package override for `talosctl` 1.7.0
- Make flake accessible with `nix shell`
- Adds `TALOSSKU` environment variable to dev cluster to hint size
- Adds informative progress messages during dev cluster setup