### PR TITLE
feat(apps): Add ezXSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Platform stack components provide common services to the cluster and abstract aw
 
 ### Application stack
 
-TBD
+Application stack components provide usable functionality to end users and rely on components in the platform and system stacks.
+
+- [`apps/ezxss`](apps/ezxss) - [ezXSS](https://github.com/ssl/ezXSS) platform for testing for XSS vulnerabilities, particularly useful for blind XSS injections.
 
 ### Root app
 

--- a/apps/ezxss/base/configmap.yaml
+++ b/apps/ezxss/base/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ezxss
+  labels:
+    app.kubernetes.io/name: ezxss
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/part-of: ezxss
+data:
+  EZXSS_DBHOST: ezxss-db
+  EZXSS_DBNAME: ezxss
+  EZXSS_DBUSER: ezxss

--- a/apps/ezxss/base/database.yaml
+++ b/apps/ezxss/base/database.yaml
@@ -1,0 +1,40 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: ezxss-db
+  labels:
+    app.kubernetes.io/name: ezxss-db
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: ezxss
+spec:
+  username: ezxss
+  database: ezxss
+  image: mariadb:11.3.2
+  storage:
+    size: 1Gi
+    storageClassName: ssd-r1
+  metrics:
+    enabled: true
+    exporter:
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault

--- a/apps/ezxss/base/deployment.yaml
+++ b/apps/ezxss/base/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ezxss
+  labels:
+    app.kubernetes.io/name: ezxss
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/component: ezxss
+    app.kubernetes.io/part-of: ezxss
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ezxss
+      app.kubernetes.io/instance: ezxss
+      app.kubernetes.io/component: ezxss
+      app.kubernetes.io/part-of: ezxss
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ezxss
+        app.kubernetes.io/instance: ezxss
+        app.kubernetes.io/component: ezxss
+        app.kubernetes.io/part-of: ezxss
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: ghcr.io/gadgetmg/ezxss:4.2@sha256:219ffd36132b338668f18f142f2bc5b7d4aabaf3fd337a108fc37240da07dac5
+        name: ezxss
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: ezxss
+        env:
+        - name: EZXSS_DBPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: ezxss-db-password
+              key: password
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/ezxss/base/kustomization.yaml
+++ b/apps/ezxss/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ezxss
+
+resources:
+- namespace.yaml
+- database.yaml
+- configmap.yaml
+- deployment.yaml
+- service.yaml

--- a/apps/ezxss/base/namespace.yaml
+++ b/apps/ezxss/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ezxss
+  labels:
+    app.kubernetes.io/instance: ezxss

--- a/apps/ezxss/base/service.yaml
+++ b/apps/ezxss/base/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ezxss
+  labels:
+    app.kubernetes.io/name: ezxss
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/component: ezxss
+    app.kubernetes.io/part-of: ezxss
+spec:
+  ports:
+  - port: 8080
+  selector:
+    app.kubernetes.io/name: ezxss
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/component: ezxss
+    app.kubernetes.io/part-of: ezxss

--- a/apps/ezxss/dev/kustomization.yaml
+++ b/apps/ezxss/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/apps/ezxss/production/kustomization.yaml
+++ b/apps/ezxss/production/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base
+- tunnelbinding.yaml

--- a/apps/ezxss/production/tunnelbinding.yaml
+++ b/apps/ezxss/production/tunnelbinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: TunnelBinding
+metadata:
+  name: ezxss
+  labels:
+    app.kubernetes.io/name: ezxss
+    app.kubernetes.io/instance: ezxss
+    app.kubernetes.io/component: tunnel
+    app.kubernetes.io/part-of: ezxss
+subjects:
+- name: ezxss
+  spec:
+    fqdn: dm3.in
+tunnelRef:
+  kind: ClusterTunnel
+  name: dm3-in

--- a/root/lib/root.libsonnet
+++ b/root/lib/root.libsonnet
@@ -68,4 +68,7 @@ local app = argo_cd.argoproj.v1alpha1.application;
   'mariadb-operator':
     app.new('mariadb-operator') + self.defaults +
     app.spec.source.withPath('platform/mariadb-operator/' + $.config.environment),
+  ezxss:
+    app.new('ezxss') + self.defaults +
+    app.spec.source.withPath('apps/ezxss/' + $.config.environment),
 }


### PR DESCRIPTION
Adds the [ezXSS](https://github.com/ssl/ezXSS) application, a XSS testing framework. Utilizes the MariaDB operator as a backing database. Exposed publicly on the Internet with a Cloudflare tunnel managed by adyanth's Cloudflare operator.