### PR TITLE
fix(ci): Use less storage in CI environment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: "Test"
 on:
   pull_request:
   push:
+    branches:
+    - main
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/platform/keycloak/dev/patches/resources.yaml
+++ b/platform/keycloak/dev/patches/resources.yaml
@@ -6,6 +6,8 @@ spec:
   instances: 1
   affinity:
     podAntiAffinityType: preferred
+  storage:
+    size: 1Gi
 ---
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: Keycloak


### PR DESCRIPTION
This reduces storage requested in GitHub actions that can exhaust storage from the runner. Additionally, updates workflow to only trigger on pull requests and pushes to main to prevent double runs.