### PR TITLE
fix(taskfile): Fixes various bugs in Taskfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,10 +1,16 @@
 version: '3'
 
+run: when_changed
+
 env:
   # renovate: datasource=github-releases depName=siderolabs/talos
   TALOS_VERSION: v1.6.7
   # renovate: datasource=github-releases depName=kubernetes/kubernetes
   KUBERNETES_VERSION: v1.29.4
+
+vars:
+  MANIFESTS: # temporary file to hold built manifests for a task
+    sh: mktemp /tmp/tmp.{{.TASK}}-XXX.yaml
 
 tasks:
   test:
@@ -18,28 +24,24 @@ tasks:
     deps: [generate-cilium-cni-patch]
     cmds:
     - hack/scripts/create-cluster.sh
+    - task: system:cilium:apply
     status:
     - docker ps | grep dev-controlplane-1
 
   cluster:destroy:
     deps: [git-mirror:stop]
     cmds:
-    - defer: talosctl config context ""
-    - defer: talosctl config remove dev --noconfirm
+    - defer: talosctl config context "" && talosctl config remove dev --noconfirm
     - defer: kubectl config unset current-context
     - defer: kubectl config delete-context admin@dev
     - defer: kubectl config delete-user admin@dev
     - defer: kubectl config delete-cluster dev
     - talosctl cluster destroy --name dev
-    status:
-    - '! kubectl config get-clusters | grep ^dev$'
 
   root:apply:
     deps: [system:argocd:apply-minimal, git-mirror:start]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/root/dev > {{.MANIFESTS}}
     - kubectl apply --server-side -f {{.MANIFESTS}}
@@ -49,11 +51,9 @@ tasks:
     - kubectl get apps/root -n argocd
 
   system:argocd:apply:
-    deps: [system:cilium:apply, platform:kube-prometheus:apply-crds]
+    deps: [platform:kube-prometheus:apply-crds]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/argocd/dev > {{.MANIFESTS}}
     - kubectl apply --server-side -f {{.MANIFESTS}}
@@ -66,8 +66,6 @@ tasks:
   system:argocd:apply-minimal:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/argocd/dev > {{.MANIFESTS}}
     - kfilt -x group=gateway.networking.k8s.io -x group=monitoring.coreos.com < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -76,16 +74,14 @@ tasks:
     - kubectl get crd/applications.argoproj.io
 
   system:cert-manager:apply:
-    deps: [platform:kube-prometheus:apply-crds, system:cilium:apply]
+    deps: [platform:kube-prometheus:apply-crds]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/cert-manager/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
     - kfilt -K CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
-    - kubectl rollout status --watch deployment.apps -n argocd
+    - kubectl rollout status --watch deployment.apps -n cert-manager
     sources:
     - '{{.ROOT_DIR}}/system/cert-manager/**/*.yaml'
     status:
@@ -94,8 +90,6 @@ tasks:
   system:cert-manager:apply-crds:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/cert-manager/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -106,12 +100,11 @@ tasks:
     deps: [system:cert-manager:apply-crds, platform:kube-prometheus:apply-crds]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/cilium/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
     - kfilt -K CustomResourceDefinition -x group=cilium.io < {{.MANIFESTS}} | kubectl apply --server-side -f -
+    - kubectl rollout restart deployment.apps/cilium-operator daemonset.apps/cilium -n kube-system
     - kubectl rollout status --watch deployment.apps/cilium-operator daemonset.apps/cilium -n kube-system
     - kfilt -i group=cilium.io < {{.MANIFESTS}} | kubectl apply --server-side -f -
     sources:
@@ -123,11 +116,10 @@ tasks:
     deps: [system:cert-manager:apply, platform:kube-prometheus:apply-crds]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/k8s-gateway/dev > {{.MANIFESTS}}
     - kubectl apply --server-side -f {{.MANIFESTS}}
+    - kubectl -n kube-system get configmap/coredns -o yaml | sed "/forward/i\        forward dev.local 10.5.0.11" | kubectl replace -f -
     sources:
     - '{{.ROOT_DIR}}/system/k8s-gateway/**/*.yaml'
     status:
@@ -137,8 +129,6 @@ tasks:
     deps: [system:cert-manager:apply]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/piraeus/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -152,8 +142,6 @@ tasks:
   platform:cloudflare-operator:apply:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/cloudflare-operator/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -164,14 +152,14 @@ tasks:
     - kubectl get ns/cloudflare-operator-system
 
   platform:cnpg:apply:
+    deps: [system:piraeus:apply]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/cnpg/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
     - kfilt -K CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
+    - kubectl rollout status --watch deployment.apps -n cnpg-system
     sources:
     - '{{.ROOT_DIR}}/platform/cnpg/**/*.yaml'
     status:
@@ -180,8 +168,6 @@ tasks:
   platform:crossplane:apply:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/crossplane/dev > {{.MANIFESTS}}
     - kfilt -x group=pkg.crossplane.io < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -196,8 +182,6 @@ tasks:
     deps: [platform:kube-prometheus:apply-crds]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/external-secrets/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -208,11 +192,9 @@ tasks:
     - kubectl get ns/external-secrets
 
   platform:keycloak:apply:
-    deps: [platform:cnpg:apply, platform:crossplane:apply, platform:external-secrets:apply, system:piraeus:apply]
+    deps: [platform:cnpg:apply, platform:crossplane:apply, platform:external-secrets:apply, system:piraeus:apply, system:k8s-gateway:apply]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/keycloak/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition -k Provider < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -224,11 +206,8 @@ tasks:
     - kubectl get ns/keycloak
 
   platform:kube-prometheus:apply:
-    deps: [system:cilium:apply]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/kube-prometheus/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -241,8 +220,6 @@ tasks:
   platform:kube-prometheus:apply-crds:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/kube-prometheus/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition -k Namespace < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -252,8 +229,6 @@ tasks:
   platform:kubevirt:apply:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/kubevirt/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -266,8 +241,6 @@ tasks:
   platform:mariadb-operator:apply:
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/platform/mariadb-operator/dev > {{.MANIFESTS}}
     - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
@@ -282,8 +255,6 @@ tasks:
     deps: [platform:mariadb-operator:apply, system:piraeus:apply]
     preconditions:
     - kubectl config current-context | grep admin@dev
-    vars:
-      MANIFESTS: {sh: mktemp}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/apps/ezxss/dev > {{.MANIFESTS}}
     - kubectl apply --server-side -f {{.MANIFESTS}}

--- a/system/cilium/dev/kustomization.yaml
+++ b/system/cilium/dev/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
 replicas:
 - name: cilium-operator
   count: 1
+
+patches:
+- path: operator-deployment.patch.yaml

--- a/system/cilium/dev/operator-deployment.patch.yaml
+++ b/system/cilium/dev/operator-deployment.patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 100%


### PR DESCRIPTION
Fixes various bugs and adds optimizations to Taskfile:
- Ensures tasks only run once instead of every time they're depended on
- Moves `MANIFESTS` var to global scope
- Updates `MANIFESTS` var to include task's name in filename to prevent files getting the same names
- Moves `system:cilium:apply` to `cmds` in `cluster:create` rather than being depended on by most things
- Triggers a restart of `cilium` pods to ensure new configuration is picked up
- Fixes watch command for `system:cert-manager:apply` that was incorrectly looking at `argocd` namespace
- Adds `system:k8s-gateway:apply` as dependency of `platform:keycloak:apply`
- Injects forwarder to `k8s-gateway` service into `coredns` ConfigMap to allow cluster to resolve `dev.local` names
- Updates `cilium-operator` Deployment to allow restarts with only one node in use
- Wait for rollout of CNPG before completing `platform:cnpg:apply`
- Fix command to remove Talos context on `cluster:destroy`