### PR TITLE
fix(ezxss): Remove conflicting labels with underlying exporter deployment

### DIFF
--- a/apps/ezxss/base/database.yaml
+++ b/apps/ezxss/base/database.yaml
@@ -3,8 +3,6 @@ kind: MariaDB
 metadata:
   name: ezxss-db
   labels:
-    app.kubernetes.io/name: ezxss-db
-    app.kubernetes.io/instance: ezxss
     app.kubernetes.io/component: database
     app.kubernetes.io/part-of: ezxss
 spec:


### PR DESCRIPTION
Removes conflicting labels on MariaDB instance with underlying exporter deployment