### PR TITLE
fix(argocd): Fix cluster-issuer annotation on Gateway resource

### DIFF
--- a/system/argocd/base/gateway.yaml
+++ b/system/argocd/base/gateway.yaml
@@ -4,6 +4,8 @@ metadata:
   name: argocd
   namespace: argocd
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   gatewayClassName: cilium

--- a/system/argocd/base/kustomization.yaml
+++ b/system/argocd/base/kustomization.yaml
@@ -51,4 +51,4 @@ patches:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "1"
   target:
-    group: (monitoring.coreos.com|gateway.networking.k8s.io)
+    group: (monitoring.coreos.com)

--- a/system/argocd/base/server-httproute.yaml
+++ b/system/argocd/base/server-httproute.yaml
@@ -3,6 +3,9 @@ kind: HTTPRoute
 metadata:
   name: argocd-server
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   hostnames:
   - argocd.seigra.net


### PR DESCRIPTION
Fixes a missing annotation on the Gateway resource for the cluster-issuer as it was previously overwritten by Kustomize. This defines all annotations explicitly on the resource.