### PR TITLE
feat(gateway): Switch primary Gateway API implementation to Envoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ System stack components are fundamental to the cluster delivering core functiona
 
 - [`system/argocd`](system/argocd) - Continuous delivery of this repository using [Argo CD](https://argo-cd.readthedocs.io/en/stable/)
 - [`system/cert-manager`](system/cert-manager) - Manages PKI certificates in the cluster with the [cert-manager](https://cert-manager.io/) and [trust-manager](https://cert-manager.io/docs/trust/trust-manager/) projects
-- [`system/cilium`](system/cilium) - [Cilium](https://cilium.io/) Container Network Interface (CNI) plugin handling all networking including access from outside the cluster using BGP and the [Gateway API](https://gateway-api.sigs.k8s.io/)
+- [`system/cilium`](system/cilium) - [Cilium](https://cilium.io/) Container Network Interface (CNI) plugin handling networking including advertising LoadBalancer routes via BGP
+- [`system/gateway-api`](system/gateway-api) - [Gateway API](https://gateway-api.sigs.k8s.io/) CRDs used by Envoy Gateway
 - [`system/k8s-gateway`](system/k8s-gateway) - An outside-facing instance of [CoreDNS with the k8s_gateway plugin](https://ori-edge.github.io/k8s_gateway/) for resolving DNS names from the LAN
 - [`system/kyverno`](system/kyverno) - [Kyverno](https://kyverno.io) Kubernetes policy engine
 - [`system/piraeus`](system/piraeus) - Container Storage Interface (CSI) plugin for [LINSTOR](https://linbit.com/linstor/) managed with the [Piraeus](https://piraeus.io/) operator
@@ -23,6 +24,7 @@ Platform stack components provide common services to the cluster and abstract aw
 - [`platform/cnpg`](platform/cnpg) - [CloudNativePG](https://cloudnative-pg.io/) operator for PostgreSQL databases
 - [`platform/crossplane`](platform/crossplane) - [Crossplane](https://www.crossplane.io/) control plane for managing non-Kubernetes resources
 - [`platform/external-secrets`](platform/external-secrets) - [External Secrets Operator](https://external-secrets.io/) for secrets management
+- [`platform/envoy-gateway`](platform/envoy-gateway) - [Envoy Gateway](https://gateway.envoyproxy.io/) implementation of the Gateway API for accepting ingress traffic into cluster services
 - [`platform/keycloak`](platform/keycloak) - [Keycloak](https://www.keycloak.org/) for identity and access management (IAM)
 - [`platform/kube-prometheus`](platform/kube-prometheus) - Kubernetes monitoring platform with the [Prometheus operator](https://prometheus-operator.dev/)
 - [`platform/kubevirt`](platform/kubevirt) - Virtualization platform with [KubeVirt](https://kubevirt.io/)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -144,16 +144,26 @@ tasks:
     - kubectl config current-context | grep @{{.ENVIRONMENT}}
     cmds:
     - hack/scripts/build.sh {{.ROOT_DIR}}/system/cilium/{{.ENVIRONMENT}} > {{.MANIFESTS}}
-    - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
-    - kfilt -K CustomResourceDefinition -x group=cilium.io < {{.MANIFESTS}} | kubectl apply --server-side --force-conflicts -f -
+    - kfilt -x group=cilium.io < {{.MANIFESTS}} | kubectl apply --server-side --force-conflicts -f -
     - kubectl rollout restart deployment.apps/cilium-operator daemonset.apps/cilium -n kube-system
     - kubectl rollout status --watch deployment.apps/cilium-operator daemonset.apps/cilium -n kube-system
     - kfilt -i group=cilium.io < {{.MANIFESTS}} | kubectl apply --server-side -f -
     sources:
     - '{{.ROOT_DIR}}/system/cilium/**/*.yaml'
     status:
-    - kubectl get gatewayclass/cilium
-  
+    - kubectl get servicemonitor/cilium-agent -n kube-system
+
+  system:gateway-api:apply:
+    preconditions:
+    - kubectl config current-context | grep @{{.ENVIRONMENT}}
+    cmds:
+    - hack/scripts/build.sh {{.ROOT_DIR}}/system/gateway-api/{{.ENVIRONMENT}} > {{.MANIFESTS}}
+    - kubectl apply --server-side -f {{.MANIFESTS}}
+    sources:
+    - '{{.ROOT_DIR}}/system/gateway-api/**/*.yaml'
+    status:
+    - kubectl get crd/gatewayclasses.gateway.networking.k8s.io
+
   system:k8s-gateway:apply:
     deps:
     - task: system:cert-manager:apply
@@ -240,6 +250,21 @@ tasks:
     - '{{.ROOT_DIR}}/platform/crossplane/**/*.yaml'
     status:
     - kubectl get ns/crossplane-system
+
+  platform:envoy-gateway:apply:
+    deps:
+    - task: system:gateway-api:apply
+      vars: { ENVIRONMENT: '{{.ENVIRONMENT}}' }
+    preconditions:
+    - kubectl config current-context | grep @{{.ENVIRONMENT}}
+    cmds:
+    - hack/scripts/build.sh {{.ROOT_DIR}}/platform/envoy-gateway/{{.ENVIRONMENT}} > {{.MANIFESTS}}
+    - kfilt -k CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
+    - kfilt -K CustomResourceDefinition < {{.MANIFESTS}} | kubectl apply --server-side -f -
+    sources:
+    - '{{.ROOT_DIR}}/platform/envoy-gateway/**/*.yaml'
+    status:
+    - kubectl get ns/envoy-gateway-system
 
   platform:external-secrets:apply:
     deps:

--- a/platform/envoy-gateway/base/envoyproxy.yaml
+++ b/platform/envoy-gateway/base/envoyproxy.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-gateway-proxy-config
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        patch:
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: envoy
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                  - name: shutdown-manager
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                  securityContext:
+                    runAsNonRoot: true
+                    seccompProfile:
+                      type: RuntimeDefault

--- a/platform/envoy-gateway/base/gatewayclass.yaml
+++ b/platform/envoy-gateway/base/gatewayclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-gateway
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: envoy-gateway-proxy-config
+    namespace: envoy-gateway-system

--- a/platform/envoy-gateway/base/kustomization.yaml
+++ b/platform/envoy-gateway/base/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: envoy-gateway-system
+
+resources:
+# renovate: datasource=github-releases depName=envoyproxy/gateway
+- https://raw.githubusercontent.com/envoyproxy/gateway/v1.0.1/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+# renovate: datasource=github-releases depName=envoyproxy/gateway
+- https://raw.githubusercontent.com/envoyproxy/gateway/v1.0.1/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+# renovate: datasource=github-releases depName=envoyproxy/gateway
+- https://raw.githubusercontent.com/envoyproxy/gateway/v1.0.1/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
+# renovate: datasource=github-releases depName=envoyproxy/gateway
+- https://raw.githubusercontent.com/envoyproxy/gateway/v1.0.1/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# renovate: datasource=github-releases depName=envoyproxy/gateway
+- https://raw.githubusercontent.com/envoyproxy/gateway/v1.0.1/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+- namespace.yaml
+- envoyproxy.yaml
+- gatewayclass.yaml
+
+helmCharts:
+- name: gateway-helm
+  repo: oci://docker.io/envoyproxy
+  releaseName: envoy-gateway
+  namespace: envoy-gateway-system
+  version: v1.0.1
+
+patches:
+- path: patches/deployment-podsecurity.yaml
+- path: patches/job-podsecurity.yaml

--- a/platform/envoy-gateway/base/namespace.yaml
+++ b/platform/envoy-gateway/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: envoy-gateway-system

--- a/platform/envoy-gateway/base/patches/deployment-podsecurity.yaml
+++ b/platform/envoy-gateway/base/patches/deployment-podsecurity.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: envoy-gateway
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault

--- a/platform/envoy-gateway/base/patches/job-podsecurity.yaml
+++ b/platform/envoy-gateway/base/patches/job-podsecurity.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: envoy-gateway-gateway-helm-certgen
+  namespace: envoy-gateway-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: envoy-gateway-certgen
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault

--- a/platform/envoy-gateway/dev/kustomization.yaml
+++ b/platform/envoy-gateway/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/platform/envoy-gateway/production/kustomization.yaml
+++ b/platform/envoy-gateway/production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/platform/keycloak/base/gateway.yaml
+++ b/platform/keycloak/base/gateway.yaml
@@ -3,7 +3,7 @@ kind: Gateway
 metadata:
   name: keycloak
 spec:
-  gatewayClassName: cilium
+  gatewayClassName: envoy-gateway
   listeners:
   - name: keycloak
     hostname: auth.seigra.net

--- a/platform/kube-prometheus/lib/gateway.libsonnet
+++ b/platform/kube-prometheus/lib/gateway.libsonnet
@@ -12,7 +12,7 @@ local gateway_api = import 'github.com/jsonnet-libs/gateway-api-libsonnet/1.0/ma
         'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
         'argocd.argoproj.io/sync-wave': '1',
       }) +
-      gw.spec.withGatewayClassName('cilium') +
+      gw.spec.withGatewayClassName('envoy-gateway') +
       gw.spec.withListeners(
         [
           l.withName($.grafana._metadata.name) +

--- a/root/lib/root.libsonnet
+++ b/root/lib/root.libsonnet
@@ -35,6 +35,9 @@ local app = argo_cd.argoproj.v1alpha1.application;
   cilium:
     app.new('cilium') + self.defaults +
     app.spec.source.withPath('system/cilium/' + $.config.environment),
+  'gateway-api':
+    app.new('gateway-api') + self.defaults +
+    app.spec.source.withPath('system/gateway-api/' + $.config.environment),
   'k8s-gateway':
     app.new('k8s-gateway') + self.defaults +
     app.spec.source.withPath('system/k8s-gateway/' + $.config.environment),
@@ -53,6 +56,9 @@ local app = argo_cd.argoproj.v1alpha1.application;
   crossplane:
     app.new('crossplane') + self.defaults +
     app.spec.source.withPath('platform/crossplane/' + $.config.environment),
+  'envoy-gateway':
+    app.new('envoy-gateway') + self.defaults +
+    app.spec.source.withPath('platform/envoy-gateway/' + $.config.environment),
   'external-secrets':
     app.new('external-secrets') + self.defaults +
     app.spec.source.withPath('platform/external-secrets/' + $.config.environment),

--- a/system/argocd/base/gateway.yaml
+++ b/system/argocd/base/gateway.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  gatewayClassName: cilium
+  gatewayClassName: envoy-gateway
   listeners:
   - allowedRoutes:
       namespaces:

--- a/system/cilium/base/kustomization.yaml
+++ b/system/cilium/base/kustomization.yaml
@@ -1,21 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
-# Gateway API prerequisites (https://docs.cilium.io/en/latest/network/servicemesh/gateway-api/gateway-api/#prerequisites)
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
-# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
-
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io
@@ -23,7 +8,6 @@ helmCharts:
   namespace: kube-system
   version: 1.15.5
   apiVersions:
-  - gateway.networking.k8s.io/v1/GatewayClass
   - monitoring.coreos.com/v1
   valuesFile: values.yaml
 

--- a/system/cilium/base/values.yaml
+++ b/system/cilium/base/values.yaml
@@ -22,9 +22,6 @@ bgpControlPlane:
   enabled: true
 l2announcements:
   enabled: true
-gatewayAPI:
-  enabled: true
-  enableAlpn: true
 encryption:
   enabled: true
   type: wireguard

--- a/system/gateway-api/base/kustomization.yaml
+++ b/system/gateway-api/base/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml
+# Omit v1alpha3 update of BackendTLSPolicy (https://gateway-api.sigs.k8s.io/guides/#backendtlspolicy)
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.0.0/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+- https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.1.0/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+
+patches:
+- patch: | # Force replace BackendTLSPolicy CRDs to downgrade from v1.1.0 to v1.0.0
+    - op: add
+      path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      value:
+        Replace=true
+  target:
+    kind: CustomResourceDefinition
+    name: backendtlspolicies.gateway.networking.k8s.io

--- a/system/gateway-api/dev/kustomization.yaml
+++ b/system/gateway-api/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/system/gateway-api/production/kustomization.yaml
+++ b/system/gateway-api/production/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base


### PR DESCRIPTION
Switches the primary implementation of the Gateway API in the cluster to Envoy Gateway and removes Gateway API support from Cilium. This works around a bug in Cilium's controller that consumes Gateway resources belonging to other classes as referenced by https://github.com/cilium/cilium/issues/31978.