### PR TITLE
fix(envoy): Don't immediately delete job so Argo CD can see it finished

### DIFF
--- a/platform/envoy-gateway/base/kustomization.yaml
+++ b/platform/envoy-gateway/base/kustomization.yaml
@@ -28,3 +28,4 @@ helmCharts:
 patches:
 - path: patches/deployment-podsecurity.yaml
 - path: patches/job-podsecurity.yaml
+- path: patches/job-ttl.yaml

--- a/platform/envoy-gateway/base/patches/job-ttl.yaml
+++ b/platform/envoy-gateway/base/patches/job-ttl.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: envoy-gateway-gateway-helm-certgen
+  namespace: envoy-gateway-system
+spec:
+  ttlSecondsAfterFinished: 30


### PR DESCRIPTION
Fixes Argo CD hanging after running presync hook job to generate certs. This ensures the job stays around long enough for Argo CD to see that it has completed successfully.