### PR TITLE
fix(argocd): Fix syntax in home-ssh-creds Secret

### DIFF
--- a/system/argocd/production/secrets.sops.yaml
+++ b/system/argocd/production/secrets.sops.yaml
@@ -6,8 +6,8 @@ metadata:
     labels:
         argocd.argoproj.io/secret-type: repo-creds
 data:
-    type: git
-    url: ENC[AES256_GCM,data:t4QJ8EdswvQwmmYsdAmsL3laRE2zmPT4GyVQIVgy0EI=,iv:wJXP+lAJEfQfrAYupbFc0zKxqYd/mVOfTZbagoh+18Q=,tag:b+5w1YqskKnepOp6vtsX7w==,type:str]
+    type: Z2l0
+    url: ENC[AES256_GCM,data:+JJb2rL5oH/TJL9pqCpR8F5HLVlx1OiX4Yn19xCGJF3645dF2GWbbl0m/nM=,iv:sO6CVAMQM02qYb/0NZ+ByZs0vQ2T5mlMDxvtlYrjong=,tag:qJb+mi1D/aXNtHGKpLBk9Q==,type:str]
     sshPrivateKey: ENC[AES256_GCM,data:3m7h5cvo0uc4mZudKDrOgEACK9LrSNSs+WfkJ5KryOvA4JX2UVVKoOwB5f1Ou/XseHFZUa9+4J43rFv/mKmxJ4LXx+ASmKuq+6LCV19PvXu/RsVPIxTN888JhsTvE5W65dKR36e6pC9FTbXJpTKkM45HT40K+orEW+0MQzIZaXffcdh6h7A8VCIT1/9fD0eTqRBSwukClqRljLgv6bZIeDJNL7tR36Wtc3WjPHlv4x+mBxoK1i1m2N141paCGnG+2U8UO6T1WiYVj/b4+zHQGWieuKMBNFCnjMkE6HLR9vPJPnSqgPkMWA1Ok0sayAEUJpZvFXHMNh7d/YX1v+9O+obN4FVPxF3g2pj+xcM/6A4+Bkikwg/16APMOjvHuH3vGWOtXp6egerP8CoHU2SDikdbUI/W4J7uFj60fl0lltnwLuB7ZhfD0ZQr9xVInO4aCsd9pBR3Sj6NMjLtqPoCXvGx5oPlosdW0VWcl2BfudYaNP9aOmxg1HDWb7myA/QcslJhGA4E0tmUn1+ormGamnDy77kcm10D/0FUNf7b/jwaaRDZuBRg8zjtafNJPBYvn3booUVevys/aG6qfpIGO97M1W0/yNETfRPhvGcgEVkxD2AKABHwP37g0v4otrQgCF/kGn8JC/+tW3z+Z5lkI4KNqB4KM3FoFJ4zekqMHL5P1X9p,iv:AJblsvAmw8ZZhC1HlsfwH8RMQyFEln8N4nd5JkPUTvQ=,tag:wqYZYWSUupPKHl9JJmw4Rg==,type:str]
 sops:
     kms: []
@@ -33,8 +33,8 @@ sops:
             dDdjZkN0NHFxd0tPOFVyTEoyRmFYNXcKVbWHj6g6+HY6jKjtSmlLbZUzF5k7h+BZ
             3lh/Aj2ZeJyGDx45GXBYmLjmRDF2Sc8/tCOu+d+gRw5GEqYcohglaw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-17T00:52:13Z"
-    mac: ENC[AES256_GCM,data:0nojHkECfzoh8wNo776O6Cd7QcSbpI37qNeB+60enYGaSvKTQpT97XLbKGFeIv9laxizWbLBrcSKirUyUMJUjGFQTCC4AwZDcW3FhvVBBBcPHyJ6koXKpAfz3hIf5BQKV+cdeyVrkFlu13mHnFve1E2Czq9tQ0lPMKVrmvI2bRk=,iv:Ol3XgbvcKBN+qGQoXd1KtdBoJ2QFwozQnKYd49hOrTo=,tag:/zM/7e6vydxXseAejUxPsA==,type:str]
+    lastmodified: "2024-06-17T18:21:47Z"
+    mac: ENC[AES256_GCM,data:2j3+VaAm86mwo9E3NW8Ily2rBJCqB5iwdOMF+yfvyixMNYUzodzFwnEAgWxlh7zZ08UvLtZprKvBq2wazXKBhUU6gMdccKDj1hpLZaHDq+uKrAJ28vY3udMcrjPV2gNcWFHX9X171c6gPJCI5R/23X/nROcplV6Jlw9HfSJrhxA=,iv:muNOeCJzD0cTUKbWBmGuBxDcTevnLnZMM1b5czOXvl4=,tag:sSYJYLFwGPeT05VAlM404g==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1
@@ -70,8 +70,8 @@ sops:
             dDdjZkN0NHFxd0tPOFVyTEoyRmFYNXcKVbWHj6g6+HY6jKjtSmlLbZUzF5k7h+BZ
             3lh/Aj2ZeJyGDx45GXBYmLjmRDF2Sc8/tCOu+d+gRw5GEqYcohglaw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-17T00:52:13Z"
-    mac: ENC[AES256_GCM,data:0nojHkECfzoh8wNo776O6Cd7QcSbpI37qNeB+60enYGaSvKTQpT97XLbKGFeIv9laxizWbLBrcSKirUyUMJUjGFQTCC4AwZDcW3FhvVBBBcPHyJ6koXKpAfz3hIf5BQKV+cdeyVrkFlu13mHnFve1E2Czq9tQ0lPMKVrmvI2bRk=,iv:Ol3XgbvcKBN+qGQoXd1KtdBoJ2QFwozQnKYd49hOrTo=,tag:/zM/7e6vydxXseAejUxPsA==,type:str]
+    lastmodified: "2024-06-17T18:21:47Z"
+    mac: ENC[AES256_GCM,data:2j3+VaAm86mwo9E3NW8Ily2rBJCqB5iwdOMF+yfvyixMNYUzodzFwnEAgWxlh7zZ08UvLtZprKvBq2wazXKBhUU6gMdccKDj1hpLZaHDq+uKrAJ28vY3udMcrjPV2gNcWFHX9X171c6gPJCI5R/23X/nROcplV6Jlw9HfSJrhxA=,iv:muNOeCJzD0cTUKbWBmGuBxDcTevnLnZMM1b5czOXvl4=,tag:sSYJYLFwGPeT05VAlM404g==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1
@@ -107,8 +107,8 @@ sops:
             dDdjZkN0NHFxd0tPOFVyTEoyRmFYNXcKVbWHj6g6+HY6jKjtSmlLbZUzF5k7h+BZ
             3lh/Aj2ZeJyGDx45GXBYmLjmRDF2Sc8/tCOu+d+gRw5GEqYcohglaw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-17T00:52:13Z"
-    mac: ENC[AES256_GCM,data:0nojHkECfzoh8wNo776O6Cd7QcSbpI37qNeB+60enYGaSvKTQpT97XLbKGFeIv9laxizWbLBrcSKirUyUMJUjGFQTCC4AwZDcW3FhvVBBBcPHyJ6koXKpAfz3hIf5BQKV+cdeyVrkFlu13mHnFve1E2Czq9tQ0lPMKVrmvI2bRk=,iv:Ol3XgbvcKBN+qGQoXd1KtdBoJ2QFwozQnKYd49hOrTo=,tag:/zM/7e6vydxXseAejUxPsA==,type:str]
+    lastmodified: "2024-06-17T18:21:47Z"
+    mac: ENC[AES256_GCM,data:2j3+VaAm86mwo9E3NW8Ily2rBJCqB5iwdOMF+yfvyixMNYUzodzFwnEAgWxlh7zZ08UvLtZprKvBq2wazXKBhUU6gMdccKDj1hpLZaHDq+uKrAJ28vY3udMcrjPV2gNcWFHX9X171c6gPJCI5R/23X/nROcplV6Jlw9HfSJrhxA=,iv:muNOeCJzD0cTUKbWBmGuBxDcTevnLnZMM1b5czOXvl4=,tag:sSYJYLFwGPeT05VAlM404g==,type:str]
     pgp: []
     unencrypted_regex: ^(apiVersion|metadata|kind|type)$
     version: 3.8.1


### PR DESCRIPTION
Fixes a syntax error in `home-ssh-creds` `Secret` resource caused after switching from `stringData` to `data`.