### PR TITLE
feat(root): Switch to ApplicationSet for all apps

### DIFF
--- a/root/dev/apps.yaml
+++ b/root/dev/apps.yaml
@@ -1,453 +1,62 @@
 apiVersion: argoproj.io/v1alpha1
-kind: Application
+kind: ApplicationSet
 metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: argocd
+  name: apps
   namespace: argocd
 spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/argocd/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cert-manager
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/cert-manager/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cilium
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/cilium/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cloudflare-operator
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/cloudflare-operator/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cnpg
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/cnpg/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: crossplane
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/crossplane/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: envoy-gateway
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/envoy-gateway/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: external-secrets
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/external-secrets/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: ezxss
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: apps/ezxss/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: gateway-api
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/gateway-api/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: k8s-gateway
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/k8s-gateway/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: keycloak
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/keycloak/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kube-prometheus
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    directory:
-      jsonnet:
-        libs:
-        - vendor
-    path: platform/kube-prometheus/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kubevirt
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/kubevirt/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kyverno
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/kyverno/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: mariadb-operator
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/mariadb-operator/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: piraeus
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/piraeus/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: root
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: root/dev
-    repoURL: http://10.5.0.254/git/repo.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - merge:
+      mergeKeys:
+      - path
+      generators:
+      - git:
+          repoURL: http://10.5.0.254/git/repo.git
+          revision: HEAD
+          directories:
+          - path: '*/*/dev'
+          - path: root/dev
+          values:
+            name: '{{index .path.segments 1 }}'
+            type: default
+      - git:
+          repoURL: http://10.5.0.254/git/repo.git
+          revision: HEAD
+          directories:
+          - path: platform/kube-prometheus/dev
+          values:
+            type: jsonnet
+      - git:
+          repoURL: http://10.5.0.254/git/repo.git
+          revision: HEAD
+          directories:
+          - path: root/dev
+          values:
+            name: root
+  template:
+    metadata:
+      name: '{{.values.name}}'
+    spec:
+      source:
+        path: '{{.path.path}}'
+        repoURL: http://10.5.0.254/git/repo.git
+        targetRevision: HEAD
+      destination:
+        name: in-cluster
+      project: default
+      syncPolicy:
+        syncOptions:
+        - ServerSideApply=true
+        automated:
+          prune: true
+          selfHeal: true
+  templatePatch: |
+    {{- if eq .values.type "jsonnet" }}
+    spec:
+      source:
+        directory:
+          jsonnet:
+            libs:
+            - vendor
+    {{- end }}

--- a/root/production/apps.yaml
+++ b/root/production/apps.yaml
@@ -1,453 +1,62 @@
 apiVersion: argoproj.io/v1alpha1
-kind: Application
+kind: ApplicationSet
 metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: argocd
+  name: apps
   namespace: argocd
 spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/argocd/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cert-manager
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/cert-manager/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cilium
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/cilium/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cloudflare-operator
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/cloudflare-operator/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: cnpg
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/cnpg/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: crossplane
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/crossplane/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: envoy-gateway
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/envoy-gateway/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: external-secrets
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/external-secrets/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: ezxss
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: apps/ezxss/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: gateway-api
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/gateway-api/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: k8s-gateway
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/k8s-gateway/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: keycloak
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/keycloak/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kube-prometheus
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    directory:
-      jsonnet:
-        libs:
-        - vendor
-    path: platform/kube-prometheus/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kubevirt
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/kubevirt/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: kyverno
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/kyverno/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: mariadb-operator
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: platform/mariadb-operator/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: piraeus
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: system/piraeus/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
-  name: root
-  namespace: argocd
-spec:
-  destination:
-    name: in-cluster
-  project: default
-  revisionHistoryLimit: 10
-  source:
-    path: root/production
-    repoURL: git@github.com:gadgetmg/home.git
-    targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    retry:
-      limit: -1
-    syncOptions:
-    - ServerSideApply=true
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - merge:
+      mergeKeys:
+      - path
+      generators:
+      - git:
+          repoURL: git@github.com:gadgetmg/home.git
+          revision: HEAD
+          directories:
+          - path: '*/*/production'
+          - path: root/production
+          values:
+            name: '{{index .path.segments 1 }}'
+            type: default
+      - git:
+          repoURL: git@github.com:gadgetmg/home.git
+          revision: HEAD
+          directories:
+          - path: platform/kube-prometheus/production
+          values:
+            type: jsonnet
+      - git:
+          repoURL: git@github.com:gadgetmg/home.git
+          revision: HEAD
+          directories:
+          - path: root/production
+          values:
+            name: root
+  template:
+    metadata:
+      name: '{{.values.name}}'
+    spec:
+      source:
+        path: '{{.path.path}}'
+        repoURL: git@github.com:gadgetmg/home.git
+        targetRevision: HEAD
+      destination:
+        name: in-cluster
+      project: default
+      syncPolicy:
+        syncOptions:
+        - ServerSideApply=true
+        automated:
+          prune: true
+          selfHeal: true
+  templatePatch: |
+    {{- if eq .values.type "jsonnet" }}
+    spec:
+      source:
+        directory:
+          jsonnet:
+            libs:
+            - vendor
+    {{- end }}


### PR DESCRIPTION
Switches `root` app to generate `Application` manifests using an `ApplicationSet` rather than explicitly.