### PR TITLE
fix(grafana): OIDC secret cannot be optional

### DIFF
--- a/platform/kube-prometheus/lib/grafana-oidc-secret.libsonnet
+++ b/platform/kube-prometheus/lib/grafana-oidc-secret.libsonnet
@@ -14,7 +14,6 @@
                       secretKeyRef: {
                         name: 'grafana-oidc-secret',
                         key: 'attribute.client_secret',
-                        optional: true,
                       },
                     },
                   },


### PR DESCRIPTION
Fixes issue on first startup if the OIDC secret does not exist. Grafana will never pick up the change and a the pods will need to be restarted to connect with OIDC.