### PR TITLE
fix(cilium): Revert "chore(deps): update helm release cilium to v1.16.0"

### DIFF
--- a/system/cilium/base/kustomization.yaml
+++ b/system/cilium/base/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   repo: https://helm.cilium.io
   releaseName: cilium
   namespace: kube-system
-  version: 1.16.0
+  version: 1.16.0-rc.2
   apiVersions:
   - monitoring.coreos.com/v1
   - gateway.networking.k8s.io/v1/GatewayClass


### PR DESCRIPTION
Reverts gadgetmg/home#269 due to breakage of production BGP configuration.