### PR TITLE
fix(k8s-gateway): Workaround bug syncing resources

### DIFF
--- a/system/k8s-gateway/base/helm/kustomization.yaml
+++ b/system/k8s-gateway/base/helm/kustomization.yaml
@@ -23,3 +23,28 @@ patches:
   target:
     kind: Deployment
     name: k8s-gateway
+# - patch: |-
+#     apiVersion: rbac.authorization.k8s.io/v1
+#     kind: ClusterRole
+#     metadata:
+#       name: k8s-gateway
+#       labels:
+#         app.kubernetes.io/name: k8s-gateway
+#         app.kubernetes.io/instance: k8s-gateway
+#     rules: []
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: k8s-gateway
+      labels:
+        app.kubernetes.io/name: k8s-gateway
+        app.kubernetes.io/instance: k8s-gateway
+    rules:
+      - apiGroups:                                                                                                                                                                                                                                                                                                                 
+        - gateway.networking.k8s.io                                                                                                                                                                                                                                                                                                
+        resources:                                                                                                                                                                                                                                                                                                                 
+        - '*'                                                                                                                                                                                                                                                                                                                      
+        verbs:                                                                                                                                                                                                                                                                                                                     
+        - watch                                                                                                                                                                                                                                                                                                                    
+        - list


### PR DESCRIPTION
Works around an issue with k8s_gateway that prevents it from syncing resources if [all experimental Gateway API resources are not installed](https://github.com/ori-edge/k8s_gateway/issues/279).