### PR TITLE
fix(k8s-gateway): Add Gateway resource to ClusterRole

### DIFF
--- a/system/k8s-gateway/base/helm/kustomization.yaml
+++ b/system/k8s-gateway/base/helm/kustomization.yaml
@@ -51,6 +51,7 @@ patches:
     - apiGroups: 
       - gateway.networking.k8s.io 
       resources: 
+      - gateways
       - grpcroutes
       - httproutes
       - tlsroutes


### PR DESCRIPTION
Adds the Gateway resource to the ClusterRole for resources k8s-gateway is allowed to access. Related to #365.