### PR TITLE
fix(k8s-gateway): Remove GRPCRoute from being monitored by k8s-gateway

### DIFF
--- a/system/k8s-gateway/base/config/Corefile
+++ b/system/k8s-gateway/base/config/Corefile
@@ -2,7 +2,7 @@
     k8s_gateway seigra.net {
       apex k8s-gateway.kube-system
       ttl 300
-      resources HTTPRoute TLSRoute GRPCRoute Ingress Service
+      resources HTTPRoute TLSRoute Ingress Service
     }
     log
     errors

--- a/system/k8s-gateway/base/helm/kustomization.yaml
+++ b/system/k8s-gateway/base/helm/kustomization.yaml
@@ -52,7 +52,6 @@ patches:
       - gateway.networking.k8s.io 
       resources: 
       - gateways
-      - grpcroutes
       - httproutes
       - tlsroutes
       verbs: 

--- a/system/k8s-gateway/dev/Corefile
+++ b/system/k8s-gateway/dev/Corefile
@@ -2,7 +2,7 @@
     k8s_gateway dev.local {
       apex k8s-gateway.kube-system
       ttl 300
-      resources HTTPRoute TLSRoute GRPCRoute Ingress Service
+      resources HTTPRoute TLSRoute Ingress Service
     }
     log
     errors


### PR DESCRIPTION
Removes unused resource type GRPCRoute causing errors syncing in k8s-gateway. Related to #365 and #366.