### PR TITLE
fix(kyverno): Restore behavior of cluster permissions for Kyverno pre-1.13

### DIFF
--- a/system/kyverno/base/values.yaml
+++ b/system/kyverno/base/values.yaml
@@ -2,10 +2,30 @@ grafana:
   enabled: true
   namespace: monitoring
 admissionController:
+  clusterRole:
+    extraResources:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - get
+      - list
+      - watch
   replicas: 3
   serviceMonitor:
     enabled: true
 backgroundController:
+  clusterRole:
+    extraResources:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - get
+      - list
+      - watch
   replicas: 2
   serviceMonitor:
     enabled: true
@@ -14,6 +34,16 @@ cleanupController:
   serviceMonitor:
     enabled: true
 reportsController:
+  clusterRole:
+    extraResources:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - get
+      - list
+      - watch
   replicas: 2
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
Restores behavior of the Kyverno chart before 1.13 by giving Kyverno permission over all cluster resources. Ref: https://kyverno.io/docs/installation/upgrading/#breaking-changes