### PR TITLE
Revert "chore(deps): update helm release kyverno to v3.3.3"

### DIFF
--- a/system/kyverno/base/kustomization.yaml
+++ b/system/kyverno/base/kustomization.yaml
@@ -9,7 +9,7 @@ helmCharts:
   repo: https://kyverno.github.io/kyverno/
   releaseName: kyverno
   namespace: kyverno
-  version: 3.3.3
+  version: 3.2.7
   valuesFile: values.yaml
   apiVersions:
   - policy/v1/PodDisruptionBudget


### PR DESCRIPTION
Reverts gadgetmg/home#372 due to broken permissions after 1.13. Documented workaround to restore previous behavior at https://kyverno.io/docs/installation/upgrading/#breaking-changes does not work.