### PR TITLE
fix(cloudflare-gateway): Rename Gateway to more descriptive name

### DIFF
--- a/system/cloudflare-gateway/production/gatewayclass.yaml
+++ b/system/cloudflare-gateway/production/gatewayclass.yaml
@@ -13,7 +13,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: gateway
+  name: cloudflare
   namespace: cloudflare-gateway
 spec:
   gatewayClassName: cloudflare


### PR DESCRIPTION
Fixes production HTTPRoute referencing "cloudflare" Gateway.