### PR TITLE
fix{ezxss): Use app-specific gateway rather than shared

### DIFF
--- a/apps/ezxss/production/gateway.yaml
+++ b/apps/ezxss/production/gateway.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ezxss-cloudflare
+  namespace: ezxss
+spec:
+  gatewayClassName: cloudflare
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http

--- a/apps/ezxss/production/httproute.yaml
+++ b/apps/ezxss/production/httproute.yaml
@@ -1,12 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: ezxss
+  name: ezxss-cloudflare
   namespace: ezxss
 spec:
   parentRefs:
-  - name: cloudflare
-    namespace: cloudflare-gateway
+  - name: ezxss-cloudflare
   hostnames:
   - dm3.in
   rules:

--- a/apps/ezxss/production/kustomization.yaml
+++ b/apps/ezxss/production/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 
 resources:
 - ../base
+- gateway.yaml
 - httproute.yaml

--- a/system/cloudflare-gateway/production/gatewayclass.yaml
+++ b/system/cloudflare-gateway/production/gatewayclass.yaml
@@ -9,15 +9,3 @@ spec:
     kind: Secret
     namespace: cloudflare-gateway
     name: cloudflare
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: cloudflare
-  namespace: cloudflare-gateway
-spec:
-  gatewayClassName: cloudflare
-  listeners:
-  - protocol: HTTP
-    port: 80
-    name: http


### PR DESCRIPTION
Follows existing convention with Cilium gateway to have one gateway per application rather than a shared gateway that all apps can add routes to.