### PR TITLE
fix(ezxss): Move version tagging to Kustomization

### DIFF
--- a/apps/ezxss/base/deployment.yaml
+++ b/apps/ezxss/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - image: ghcr.io/gadgetmg/ezxss:4.2@sha256:219ffd36132b338668f18f142f2bc5b7d4aabaf3fd337a108fc37240da07dac5
+      - image: ghcr.io/gadgetmg/ezxss
         name: ezxss
         ports:
         - containerPort: 8080

--- a/apps/ezxss/base/kustomization.yaml
+++ b/apps/ezxss/base/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 - deployment.yaml
 - service.yaml
 
+images:
+- name: ghcr.io/gadgetmg/ezxss
+  newTag: 4.2@sha256:219ffd36132b338668f18f142f2bc5b7d4aabaf3fd337a108fc37240da07dac5


### PR DESCRIPTION
Moves version tagging to Kustomization to support native version management by Renovate.