### PR TITLE
fix(argocd): Add startup and liveness probes to Dex

### DIFF
--- a/system/argocd/base/kustomization.yaml
+++ b/system/argocd/base/kustomization.yaml
@@ -37,6 +37,7 @@ configMapGenerator:
 patches:
 - path: patches/ksops.yaml
 - path: patches/delete.yaml
+- path: patches/dex-probe.yaml
   target:
     name: argocd-redis.*
 - patch: |

--- a/system/argocd/base/patches/dex-probe.yaml
+++ b/system/argocd/base/patches/dex-probe.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-dex-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: dex
+        startupProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /api/dex/healthz
+            port: 5556
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /api/dex/.well-known/openid-configuration
+            port: 5556
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5

--- a/system/argocd/tasks.yaml
+++ b/system/argocd/tasks.yaml
@@ -9,5 +9,6 @@ tasks:
     - :system:crossplane:apply
     - :system:kyverno:apply
     - :system:cert-manager:apply
+    - :system:keycloak:apply
     cmds:
     - task: default-apply


### PR DESCRIPTION
Patches the Dex deployment to have startup and liveness probes. This prevents OIDC sign-ins breaking when the upstream IdP is down as Dex gives up after a failure to connect.

Resolves #376