### PR TITLE
feat(piraeus): Add HDD pool

### DIFF
--- a/system/piraeus/production/pools.yaml
+++ b/system/piraeus/production/pools.yaml
@@ -8,4 +8,12 @@ spec:
     lvmThinPool: {}
     source:
       hostDevices:
-      - /dev/sda
+      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09003
+      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09034
+      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09035
+  - name: hdd
+    lvmThinPool: {}
+    source:
+      hostDevices:
+      - '/dev/disk/by-id/usb-WD_easystore_264D_3654475432533746-0:0'
+      - '/dev/disk/by-id/usb-WD_easystore_264D_3654483237453243-0:0'

--- a/system/piraeus/production/storageclasses.yaml
+++ b/system/piraeus/production/storageclasses.yaml
@@ -35,3 +35,41 @@ parameters:
 reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hdd-r1
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+  linstor.csi.linbit.com/autoPlace: "1"
+  linstor.csi.linbit.com/storagePool: hdd
+  linstor.csi.linbit.com/layerList: drbd luks storage
+  DrbdOptions/Disk/disk-flushes: "no"
+  DrbdOptions/Disk/md-flushes: "no"
+  DrbdOptions/Net/max-buffers: "10000"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hdd-r2
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+  linstor.csi.linbit.com/autoPlace: "3"
+  linstor.csi.linbit.com/storagePool: hdd
+  linstor.csi.linbit.com/layerList: drbd luks storage
+  DrbdOptions/Disk/disk-flushes: "no"
+  DrbdOptions/Disk/md-flushes: "no"
+  DrbdOptions/Net/max-buffers: "10000"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Adds an HDD pool in the production cluster. References devices by relative name to prevent unexpected changes by the OS.