### PR TITLE
fix(piraeus): Configure storage pools per node

### DIFF
--- a/system/piraeus/production/pools.yaml
+++ b/system/piraeus/production/pools.yaml
@@ -1,19 +1,51 @@
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
-  name: pools
+  name: production-controlplane-1-pools
 spec:
+  nodeSelector:
+    kubernetes.io/hostname: production-controlplane-1
+  storagePools:
+  - name: ssd
+    lvmThinPool: {}
+    source:
+      hostDevices:
+      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09034
+  - name: hdd
+    lvmThinPool: {}
+    source:
+      hostDevices:
+      - '/dev/disk/by-id/usb-WD_easystore_264D_3654475432533746-0:0'
+---
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: production-controlplane-2-pools
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: production-controlplane-2
+  storagePools:
+  - name: ssd
+    lvmThinPool: {}
+    source:
+      hostDevices:
+      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09035
+  - name: hdd
+    lvmThinPool: {}
+    source:
+      hostDevices:
+      - '/dev/disk/by-id/usb-WD_easystore_264D_3654483237453243-0:0'
+---
+apiVersion: piraeus.io/v1
+kind: LinstorSatelliteConfiguration
+metadata:
+  name: production-controlplane-3-pools
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: production-controlplane-3
   storagePools:
   - name: ssd
     lvmThinPool: {}
     source:
       hostDevices:
       - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09003
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09034
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09035
-  - name: hdd
-    lvmThinPool: {}
-    source:
-      hostDevices:
-      - '/dev/disk/by-id/usb-WD_easystore_264D_3654475432533746-0:0'
-      - '/dev/disk/by-id/usb-WD_easystore_264D_3654483237453243-0:0'


### PR DESCRIPTION
Gives each satellite a configuration that matches the disks present on their system and not any of the other nodes' disks.