### PR TITLE
chore(migrate): Move paperless data to HDD storage

### DIFF
--- a/apps/paperless-ngx/base/paperless-ngx/pvcs.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/pvcs.yaml
@@ -3,21 +3,21 @@ kind: PersistentVolumeClaim
 metadata:
   name: paperless-ngx-data
 spec:
-  storageClassName: ssd-r3
+  storageClassName: hdd-r2
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 200Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: paperless-ngx-media
 spec:
-  storageClassName: ssd-r3
+  storageClassName: hdd-r2
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 200Gi

--- a/system/piraeus/production/storageclasses.yaml
+++ b/system/piraeus/production/storageclasses.yaml
@@ -64,7 +64,7 @@ metadata:
 provisioner: linstor.csi.linbit.com
 parameters:
   linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
-  linstor.csi.linbit.com/autoPlace: "3"
+  linstor.csi.linbit.com/autoPlace: "2"
   linstor.csi.linbit.com/storagePool: hdd
   linstor.csi.linbit.com/layerList: drbd luks storage
   DrbdOptions/Disk/disk-flushes: "no"


### PR DESCRIPTION
Commits desired state of storageClasses to use for Paperless data.