### PR TITLE
feat(velero): Add velero

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ System stack components are fundamental to the cluster delivering core functiona
 - [`system/kyverno`](system/kyverno) - [Kyverno](https://kyverno.io) Kubernetes policy engine
 - [`system/mariadb-operator`](system/mariadb-operator) - [MariaDB Operator](https://github.com/mariadb-operator/mariadb-operator) for MariaDB databases.
 - [`system/piraeus`](system/piraeus) - Container Storage Interface (CSI) plugin for [LINSTOR](https://linbit.com/linstor/) managed with the [Piraeus](https://piraeus.io/) operator
+- [`system/velero`](system/velero) - [Velero](https://velero.io/) for Kubernetes resource and persistent volume backups
 
 ### Application stack
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,6 +19,7 @@ includes:
   system:kyverno: system/kyverno/tasks.yaml
   system:mariadb-operator: system/mariadb-operator/tasks.yaml
   system:piraeus: system/piraeus/tasks.yaml
+  system:velero: system/velero/tasks.yaml
 
 run: when_changed
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             talhelper
             talosctl
             vcluster
+            velero
             yamlfmt
             yq-go
           ];

--- a/system/piraeus/base/kustomization.yaml
+++ b/system/piraeus/base/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 - internal-ca.yaml
 - api-ca.yaml
 - https://github.com/piraeusdatastore/piraeus-operator/config/default?ref=v2.7.1
+- https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=v8.1.0
+- https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=v8.1.0
 - cluster.yaml
 - satellite-internal-tls.yaml
 - talos-loader-overrides.yaml

--- a/system/velero/base/backupstoragelocation.yaml
+++ b/system/velero/base/backupstoragelocation.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/velero.io/backupstoragelocation_v1.json
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  name: default
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+spec:
+  provider: aws
+  accessMode: ReadWrite
+  default: true
+  objectStorage:
+    bucket: velero
+  config:
+    region: minio
+    s3ForcePathStyle: "true"
+    s3Url: https://truenas.lan.seigra.net:9000

--- a/system/velero/base/kustomization.yaml
+++ b/system/velero/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- backupstoragelocation.yaml
+- volumesnapshotlocation.yaml
+- volumesnapshotclass.yaml
+- schedule.yaml
+
+images:
+- name: velero/velero
+  newTag: v1.15.0@sha256:8a82ab0b14a8fc479cf494172c0f7d168d018a3bb1d19c9a0d8889d3039288fc
+- name: velero/velero-plugin-for-aws
+  newTag: v1.11.0@sha256:80d5b5176d29d4f1294d7e561b3c13a3417d775f7479995171f5b147fc3c705e
+
+helmCharts:
+- name: velero
+  repo: https://vmware-tanzu.github.io/helm-charts
+  releaseName: velero
+  namespace: velero
+  version: 8.1.0
+  valuesFile: values.yaml
+  includeCRDs: true

--- a/system/velero/base/namespace.yaml
+++ b/system/velero/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/part-of: velero

--- a/system/velero/base/schedule.yaml
+++ b/system/velero/base/schedule.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/velero.io/schedule_v1.json
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-all
+  namespace: velero
+spec:
+  schedule: 0 5 * * *
+  skipImmediately: false
+  template:
+    csiSnapshotTimeout: 0s
+    hooks: {}
+    includedNamespaces:
+    - '*'
+    itemOperationTimeout: 0s
+    metadata: {}
+    ttl: 0s
+  useOwnerReferencesInBackup: false

--- a/system/velero/base/values.yaml
+++ b/system/velero/base/values.yaml
@@ -1,0 +1,33 @@
+initContainers:
+- name: velero-plugin-for-aws
+  image: velero/velero-plugin-for-aws
+  volumeMounts:
+  - mountPath: /target
+    name: plugins
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+containerSecurityContext:
+  runAsUser: 1002
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+    add: []
+  readOnlyRootFilesystem: true
+upgradeCRDs: false
+configuration:
+  backupStorageLocation: []
+  volumeSnapshotLocation: []
+  features: EnableCSI
+credentials:
+  existingSecret: velero
+snapshotsEnabled: true

--- a/system/velero/base/volumesnapshotclass.yaml
+++ b/system/velero/base/volumesnapshotclass.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/snapshot.storage.k8s.io/volumesnapshotclass_v1.json
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: linstor-csi-velero
+  labels:
+    velero.io/csi-volumesnapshot-class: "true"
+driver: linstor.csi.linbit.com
+deletionPolicy: Retain
+parameters:
+  snap.linstor.csi.linbit.com/type: S3
+  snap.linstor.csi.linbit.com/remote-name: minio
+  snap.linstor.csi.linbit.com/allow-incremental: "true"
+  snap.linstor.csi.linbit.com/s3-bucket: velero
+  snap.linstor.csi.linbit.com/s3-endpoint: https://truenas.lan.seigra.net:9000
+  snap.linstor.csi.linbit.com/s3-use-path-style: "true"
+  snap.linstor.csi.linbit.com/s3-signing-region: minio
+  csi.storage.k8s.io/snapshotter-secret-name: linstor-csi-velero
+  csi.storage.k8s.io/snapshotter-secret-namespace: velero

--- a/system/velero/base/volumesnapshotlocation.yaml
+++ b/system/velero/base/volumesnapshotlocation.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/velero.io/volumesnapshotlocation_v1.json
+apiVersion: velero.io/v1
+kind: VolumeSnapshotLocation
+metadata:
+  name: default
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+spec:
+  provider: aws
+  config:
+    bucket: velero
+    region: minio
+    s3ForcePathStyle: "true"
+    s3Url: https://truenas.lan.seigra.net:9000

--- a/system/velero/dev/kustomization.yaml
+++ b/system/velero/dev/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base
+- secret.yaml
+
+patches:
+- patch: |
+    - op: replace
+      path: /spec/objectStorage/bucket
+      value: velero-test
+  target:
+    kind: BackupStorageLocation
+    name: default
+- patch: |
+    - op: replace
+      path: /spec/config/bucket
+      value: velero-test
+  target:
+    kind: VolumeSnapshotLocation
+    name: default
+- patch: |
+    - op: replace
+      path: /parameters/snap.linstor.csi.linbit.com~1s3-bucket
+      value: velero-test
+  target:
+    kind: VolumeSnapshotClass
+    name: linstor-csi-velero

--- a/system/velero/dev/secret.yaml
+++ b/system/velero/dev/secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+type: Opaque
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id = TESTTEST
+    aws_secret_access_key = TESTTEST
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linstor-csi-velero
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+type: Opaque
+stringData:
+  access-key: TESTTEST
+  secret-key: TESTTEST

--- a/system/velero/production/kustomization.yaml
+++ b/system/velero/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base
+
+generators:
+- secrets-generator.yaml

--- a/system/velero/production/secrets-generator.yaml
+++ b/system/velero/production/secrets-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secrets-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+- secrets.sops.yaml

--- a/system/velero/production/secrets.sops.yaml
+++ b/system/velero/production/secrets.sops.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+type: Opaque
+data:
+  cloud: ENC[AES256_GCM,data:YL0EliXXulv3Uv0w1/h1E1T2tbGzt4Wlb41oeROTcNWX7EoC229oHi8LOJ7awNLiMwpnKjtQ+GljwItBURp1ug/VCMq2yI/t/kfVrBxQIjq1RRjq1vQDrecGQcai4UplhSAy3IAcsDINeZVYsnBdRfnYUyWOgKeN8EUS14MDUmGho63h7k7G2gkIFyY92njxaan6TWNsbug43WpI,iv:CkB/DkIqeisW00jD6lZyY/uBWuFP4qzLD2FKDUng/SM=,tag:UBiuzojM5VBddNzsmarv4g==,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age14j53rr640k25j2z5q3y2dl3um0kkp2tlh4ptm8espz8ws907z9eqzlpevn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY3VLQlNUUkI4dFZxWHov
+        ZXpJNVlmcmpHSW9xaEI5WlU4RDN3ZTJvam5NCkxtaVNYMWJyT2Q5L1I1cXpFTHVM
+        VjljWThUdU9QOFlUQm1aNGEyem5EUlEKLS0tIDAwa0tZUnZWVU9aSnQ4VCs4Mzha
+        TVR3Wk9ZdlU3MkpOR04wSXEzd1VVMWcK2oiqEb+jiaVf7pK/Lbqjav3/11WRTWZU
+        j2ryYxtjxVKGz2efe2Xp62HObQz8CeziWTSjf/jb0IU8SBHiRagaKQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1lzq4n9az8872zn99787s8dg8zleg26nhq79luf5hgs40ry057cyqkhu55m
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByOGZCRjNNMldteGJtSUc4
+        VTROUEJXb0plWm1uNGI3TGxqZ01LSUtNMmhvCmY2bEFoRU1hS1F6S0lrK0pTdmFO
+        Q2lsSUMxeGlQaTFFYXVRUWFUdXpFMFEKLS0tIHgrZDNtc01rTDByaU0xeVV6WEFr
+        dDdjZkN0NHFxd0tPOFVyTEoyRmFYNXcKVbWHj6g6+HY6jKjtSmlLbZUzF5k7h+BZ
+        3lh/Aj2ZeJyGDx45GXBYmLjmRDF2Sc8/tCOu+d+gRw5GEqYcohglaw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-11-29T19:58:28Z"
+  mac: ENC[AES256_GCM,data:zFzy9gKRyla2Jt1ls/3gaXooW3w9kHO+kKN0CjCuThEJ9kCjebf3cYLdCF2R2lzbGV9JjofDgNac2Y49dEfahQJAMcboOKWcVLtuZKqNGEAdlu7a47gc/bNcq3SuDtqixNAiVuFqvMEKfdRHL9AnantnSG9iKPuSAZV30nJvyDw=,iv:hRL8BSQ6CXl3bNof4HAseDa0srFlJY0zMALP3Hynwv8=,tag:tXLlJqNYqx9Eu7X5Ilhn/Q==,type:str]
+  pgp: []
+  unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+  version: 3.9.1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linstor-csi-velero
+  namespace: velero
+  labels:
+    app.kubernetes.io/name: velero
+    app.kubernetes.io/instance: velero
+type: Opaque
+data:
+  access-key: ENC[AES256_GCM,data:l5teqCopxCFTb9bbMc0QU5iJqZ9PvDatUr2FVQ==,iv:QeswjnNZKDrnk8Nv7NzMTlYPXzJCS15Mabx0SMOnupQ=,tag:ZKMW7w6qE1QxUFfO3IXB6w==,type:str]
+  secret-key: ENC[AES256_GCM,data:6khsvFJ1RPyBFTbtUDOfskYB3mokXcsCiaNfUs648y3YEgW0C1osb9blJ0Z25eagmyHHpaG0dBM=,iv:byrAGa/XjUa4PI6GpJad/uUxodPwUzUGOOypps7CqoQ=,tag:N/a+s19HHmZti3H5whUxIA==,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age14j53rr640k25j2z5q3y2dl3um0kkp2tlh4ptm8espz8ws907z9eqzlpevn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoY3VLQlNUUkI4dFZxWHov
+        ZXpJNVlmcmpHSW9xaEI5WlU4RDN3ZTJvam5NCkxtaVNYMWJyT2Q5L1I1cXpFTHVM
+        VjljWThUdU9QOFlUQm1aNGEyem5EUlEKLS0tIDAwa0tZUnZWVU9aSnQ4VCs4Mzha
+        TVR3Wk9ZdlU3MkpOR04wSXEzd1VVMWcK2oiqEb+jiaVf7pK/Lbqjav3/11WRTWZU
+        j2ryYxtjxVKGz2efe2Xp62HObQz8CeziWTSjf/jb0IU8SBHiRagaKQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1lzq4n9az8872zn99787s8dg8zleg26nhq79luf5hgs40ry057cyqkhu55m
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByOGZCRjNNMldteGJtSUc4
+        VTROUEJXb0plWm1uNGI3TGxqZ01LSUtNMmhvCmY2bEFoRU1hS1F6S0lrK0pTdmFO
+        Q2lsSUMxeGlQaTFFYXVRUWFUdXpFMFEKLS0tIHgrZDNtc01rTDByaU0xeVV6WEFr
+        dDdjZkN0NHFxd0tPOFVyTEoyRmFYNXcKVbWHj6g6+HY6jKjtSmlLbZUzF5k7h+BZ
+        3lh/Aj2ZeJyGDx45GXBYmLjmRDF2Sc8/tCOu+d+gRw5GEqYcohglaw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2024-11-29T19:58:28Z"
+  mac: ENC[AES256_GCM,data:zFzy9gKRyla2Jt1ls/3gaXooW3w9kHO+kKN0CjCuThEJ9kCjebf3cYLdCF2R2lzbGV9JjofDgNac2Y49dEfahQJAMcboOKWcVLtuZKqNGEAdlu7a47gc/bNcq3SuDtqixNAiVuFqvMEKfdRHL9AnantnSG9iKPuSAZV30nJvyDw=,iv:hRL8BSQ6CXl3bNof4HAseDa0srFlJY0zMALP3Hynwv8=,tag:tXLlJqNYqx9Eu7X5Ilhn/Q==,type:str]
+  pgp: []
+  unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+  version: 3.9.1

--- a/system/velero/tasks.yaml
+++ b/system/velero/tasks.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+tasks:
+  apply:
+    deps:
+    - :system:piraeus:apply
+    cmds:
+    - task: default-apply


### PR DESCRIPTION
Adds Velero for backing up Kubernetes resources as well as PV data. Enables snapshotting capability in Linstor to support automatically shipping volume snapshots to S3 via the CSI driver. Backups are stored off-cluster in a local TrueNAS appliance running MinIO.

This configures a daily backup of all resources at 5:00 AM.

Note that snapshotting does not currently work in the dev cluster as it's configured for file-based pools which do not support this capability.