### PR TITLE
fix(velero): Add owner reference in backups created by schedule

### DIFF
--- a/system/velero/base/schedule.yaml
+++ b/system/velero/base/schedule.yaml
@@ -15,4 +15,4 @@ spec:
     itemOperationTimeout: 0s
     metadata: {}
     ttl: 0s
-  useOwnerReferencesInBackup: false
+  useOwnerReferencesInBackup: true


### PR DESCRIPTION
Fixes ArgoCD immediately deleting "Backup" resources when they are generated by the Schedule. Ref: https://github.com/vmware-tanzu/velero/issues/4093