### PR TITLE
fix(actual): Add missing protocol field to service definition

### DIFF
--- a/apps/actual/base/actual-server/service.yaml
+++ b/apps/actual/base/actual-server/service.yaml
@@ -9,5 +9,6 @@ spec:
   ports:
   - port: 80
     targetPort: 5006
+    protocol: TCP
   selector:
     app.kubernetes.io/name: actual-server


### PR DESCRIPTION
Fixes a missing protocol needed in the service definition when both port and targetPort are specified.