### PR TITLE
fix(gitops): Fix missing APIVersions passed to helm templates and wrong velero namespace name

### DIFF
--- a/infrastructure/controllers/cilium/base/kustomization.yaml
+++ b/infrastructure/controllers/cilium/base/kustomization.yaml
@@ -10,7 +10,6 @@ helmCharts:
   version: 1.16.5
   apiVersions:
   - monitoring.coreos.com/v1
-  - gateway.networking.k8s.io/v1/GatewayClass
   valuesInline:
     k8sServiceHost: localhost
     k8sServicePort: 7445

--- a/infrastructure/controllers/velero/base/kustomization.yaml
+++ b/infrastructure/controllers/velero/base/kustomization.yaml
@@ -18,6 +18,8 @@ helmCharts:
   namespace: velero
   version: 8.3.0
   includeCRDs: true
+  apiVersions:
+  - monitoring.coreos.com/v1
   valuesInline:
     initContainers:
     - name: velero-plugin-for-aws

--- a/infrastructure/controllers/velero/base/namespace.yaml
+++ b/infrastructure/controllers/velero/base/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mariadb-system
+  name: velero

--- a/infrastructure/gitops/base/kustomization.yaml
+++ b/infrastructure/gitops/base/kustomization.yaml
@@ -19,6 +19,8 @@ helmCharts:
   releaseName: argocd
   namespace: argocd
   version: 7.7.15
+  apiVersions:
+  - monitoring.coreos.com/v1
   valuesInline:
     configs:
       params:

--- a/manifests/dev/infrastructure/controllers/velero/v1_namespace_velero.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/v1_namespace_velero.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mariadb-system
+  name: velero

--- a/manifests/dev/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
+++ b/manifests/dev/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -104,3 +104,14 @@ rules:
   - storageclasses
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - list
+  - watch
+  - update
+  - delete

--- a/manifests/production/infrastructure/controllers/velero/v1_namespace_velero.yaml
+++ b/manifests/production/infrastructure/controllers/velero/v1_namespace_velero.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: mariadb-system
+  name: velero

--- a/manifests/production/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
+++ b/manifests/production/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -104,3 +104,14 @@ rules:
   - storageclasses
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - list
+  - watch
+  - update
+  - delete

--- a/platform/monitoring/base/kustomization.yaml
+++ b/platform/monitoring/base/kustomization.yaml
@@ -13,6 +13,8 @@ helmCharts:
   releaseName: kube-prometheus-stack
   namespace: monitoring
   version: 67.10.0
+  apiVersions:
+  - discovery.k8s.io/v1/EndpointSlice
   valuesInline:
     fullnameOverride: k8s
     grafana:
@@ -61,6 +63,8 @@ helmCharts:
   releaseName: prometheus-adapter
   namespace: monitoring
   version: 4.11.0
+  apiVersions:
+  - apiregistration.k8s.io/v1
   valuesInline:
     prometheus:
       url: http://k8s-prometheus.monitoring.svc


### PR DESCRIPTION
Fixes incomplete or incorrect resources generated by helm due to wrong capable APIVersions being passed to Kustomize for helm charts.