### PR TITLE
fix(ci): Fix pre-commit to bypass no-commit-to-branch rule

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,6 @@ jobs:
         restore-keys: |
           .task-${{ github.ref_name }}-
           .task-
-    - run: pre-commit run --all-files
+    - run: SKIP=no-commit-to-branch pre-commit run --all-files
     - uses: pre-commit-ci/lite-action@v1.1.0
       if: always()


### PR DESCRIPTION
Fixes pre-commit CI job from failing on main branch due to the `no-commit-to-branch` rule.