### PR TITLE
fix(ci): Switch pre-commit-ci-lite to git-auto-commit-action

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,5 +26,8 @@ jobs:
           .task-${{ github.ref_name }}-
           .task-
     - run: SKIP=no-commit-to-branch pre-commit run --all-files
-    - uses: pre-commit-ci/lite-action@v1.1.0
+    - uses: stefanzweifel/git-auto-commit-action@v5.1.0
       if: always()
+      with:
+        commit_message: '[pre-commit] automatic fixes'
+        token: ${{ secrets.PRECOMMIT_PAT }}


### PR DESCRIPTION
The [`pre-commit-ci-lite`](https://github.com/pre-commit-ci/lite-action) action cannot push a commit to a branch after a bot like renovate. Hence, switching to [`git-auto-commit-action`](https://github.com/stefanzweifel/git-auto-commit-action) which has no such restriction.