### PR TITLE
feat(kustomize): Strip helm labels

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: '3'
+version: "3"
 
 output: prefixed
 
@@ -34,12 +34,12 @@ tasks:
     - talhelper genconfig
 
   clusters:production:apply-insecure:
-    deps: ['clusters:production:genconfig']
+    deps: ["clusters:production:genconfig"]
     cmds:
     - talhelper gencommand apply --extra-flags "--insecure" | sh
 
   clusters:production:bootstrap:
-    deps: ['clusters:production:genconfig']
+    deps: ["clusters:production:genconfig"]
     cmds:
     - talhelper gencommand bootstrap | sh
     - talosctl health -n 10.1.2.11 --talosconfig=./clusterconfig/talosconfig
@@ -50,14 +50,15 @@ tasks:
   build:
     label: build-{{ .KUSTOMIZATION | replace "/" "-" }}
     sources:
-    - '{{ .KUSTOMIZATION }}/**/*'
-    - '{{ .KUSTOMIZATION }}/../base/**/*'
+    - "{{ .KUSTOMIZATION }}/**/*"
+    - "{{ .KUSTOMIZATION }}/../base/**/*"
+    - shared/**/*
     vars:
       APPLICATION: '{{ dir .KUSTOMIZATION | trimPrefix .ROOT_DIR | trimPrefix "/" }}'
-      ENVIRONMENT: '{{ base .KUSTOMIZATION }}'
-      OUTDIR: '{{ .ROOT_DIR }}/manifests/{{ .ENVIRONMENT }}/{{ .APPLICATION }}/'
+      ENVIRONMENT: "{{ base .KUSTOMIZATION }}"
+      OUTDIR: "{{ .ROOT_DIR }}/manifests/{{ .ENVIRONMENT }}/{{ .APPLICATION }}/"
     generates:
-    - '{{ .OUTDIR }}**'
+    - "{{ .OUTDIR }}**"
     cmds:
     - mkdir -p {{ .OUTDIR }}
     - rm -rf {{ .OUTDIR }}**
@@ -76,16 +77,11 @@ tasks:
     - for: sources
       task: build
       vars:
-        KUSTOMIZATION: '{{ dir .ITEM }}'
+        KUSTOMIZATION: "{{ dir .ITEM }}"
     method: none
 
   kubeconform:
     sources:
     - manifests/**/*
     cmds:
-    - kubeconform -output pretty
-        -kubernetes-version {{ .KUBERNETES_VERSION | trimPrefix "v" }}
-        -schema-location default
-        -schema-location 'schemas/{{`{{.Group}}`}}/{{`{{.ResourceKind}}`}}_{{`{{.ResourceAPIVersion}}`}}.json'
-        -skip CustomResourceDefinition,EnvoyProxy
-        manifests/
+    - kubeconform -output pretty -kubernetes-version {{ .KUBERNETES_VERSION | trimPrefix "v" }} -schema-location default -schema-location 'schemas/{{`{{.Group}}`}}/{{`{{.ResourceKind}}`}}_{{`{{.ResourceAPIVersion}}`}}.json' -skip CustomResourceDefinition,EnvoyProxy manifests/

--- a/infrastructure/controllers/cert-manager/base/kustomization.yaml
+++ b/infrastructure/controllers/cert-manager/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: cert-manager
   repo: https://charts.jetstack.io

--- a/infrastructure/controllers/cilium/base/kustomization.yaml
+++ b/infrastructure/controllers/cilium/base/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: cilium
   repo: https://helm.cilium.io

--- a/infrastructure/controllers/cnpg/base/kustomization.yaml
+++ b/infrastructure/controllers/cnpg/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: cloudnative-pg
   repo: https://cloudnative-pg.io/charts

--- a/infrastructure/controllers/crossplane/base/kustomization.yaml
+++ b/infrastructure/controllers/crossplane/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: crossplane
   repo: https://charts.crossplane.io/stable

--- a/infrastructure/controllers/envoy-gateway/base/kustomization.yaml
+++ b/infrastructure/controllers/envoy-gateway/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: gateway-helm
   repo: oci://docker.io/envoyproxy

--- a/infrastructure/controllers/external-secrets/base/kustomization.yaml
+++ b/infrastructure/controllers/external-secrets/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: external-secrets
   repo: https://charts.external-secrets.io

--- a/infrastructure/controllers/kyverno/base/kustomization.yaml
+++ b/infrastructure/controllers/kyverno/base/kustomization.yaml
@@ -5,6 +5,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: kyverno
   repo: https://kyverno.github.io/kyverno/

--- a/infrastructure/controllers/mariadb-operator/base/kustomization.yaml
+++ b/infrastructure/controllers/mariadb-operator/base/kustomization.yaml
@@ -7,6 +7,9 @@ namespace: mariadb-system
 resources:
 - namespace.yaml
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: mariadb-operator
   repo: https://mariadb-operator.github.io/mariadb-operator

--- a/infrastructure/controllers/sealed-secrets/base/kustomization.yaml
+++ b/infrastructure/controllers/sealed-secrets/base/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: sealed-secrets
   repo: https://bitnami-labs.github.io/sealed-secrets

--- a/infrastructure/controllers/trust-manager/base/kustomization.yaml
+++ b/infrastructure/controllers/trust-manager/base/kustomization.yaml
@@ -2,6 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: trust-manager
   repo: https://charts.jetstack.io

--- a/infrastructure/controllers/velero/base/kustomization.yaml
+++ b/infrastructure/controllers/velero/base/kustomization.yaml
@@ -11,6 +11,9 @@ images:
 - name: velero/velero-plugin-for-aws
   newTag: v1.11.1@sha256:3b0c402e0d55eb797a7ebe1f2525f18bdcdca8ee826680cd2d7cf657071e9d58
 
+components:
+- ../../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: velero
   repo: https://vmware-tanzu.github.io/helm-charts

--- a/infrastructure/crds/base/kustomization.yaml
+++ b/infrastructure/crds/base/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
 - https://raw.githubusercontent.com/envoyproxy/gateway/refs/tags/v1.2.5/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
 - https://raw.githubusercontent.com/envoyproxy/gateway/refs/tags/v1.2.5/charts/gateway-helm/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
 
+components:
+- ../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: prometheus-operator-crds
   repo: https://prometheus-community.github.io/helm-charts

--- a/infrastructure/gitops/base/kustomization.yaml
+++ b/infrastructure/gitops/base/kustomization.yaml
@@ -13,6 +13,9 @@ resources:
 - keycloak/storeconfig.yaml
 - vcluster-argocd-secret-sync.yaml
 
+components:
+- ../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: argo-cd
   repo: https://argoproj.github.io/argo-helm

--- a/manifests/dev/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cert-manager-webhook.yaml
@@ -7,10 +7,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cert-manager-webhook.yaml
@@ -7,10 +7,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificates.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificates.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_clusterissuers.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_clusterissuers.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_issuers.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_issuers.cert-manager.io.yaml
@@ -7,10 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_orders.acme.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_orders.acme.cert-manager.io.yaml
@@ -7,10 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: cainjector
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: cert-manager
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_monitoring.coreos.com_v1_servicemonitor_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_monitoring.coreos.com_v1_servicemonitor_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     prometheus: default
   name: cert-manager
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-startupapicheck-create-cert.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-startupapicheck-create-cert.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck:create-cert
   namespace: cert-manager
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-tokenrequest.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-tokenrequest.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-tokenrequest
   namespace: cert-manager
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-webhook-dynamic-serving.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-webhook-dynamic-serving.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cert-manager-tokenrequest.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cert-manager-tokenrequest.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cert-manager-tokenrequest
   namespace: cert-manager
 roleRef:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-startupapicheck-create-cert.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-startupapicheck-create-cert.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck:create-cert
   namespace: cert-manager
 roleRef:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-webhook-dynamic-serving.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-webhook-dynamic-serving.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_configmap_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_configmap_cert-manager.yaml
@@ -10,9 +10,6 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-cainjector.yaml
@@ -6,9 +6,6 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-startupapicheck.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-startupapicheck.yaml
@@ -10,9 +10,6 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-webhook.yaml
@@ -6,9 +6,6 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager.yaml
@@ -6,9 +6,6 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-cainjector-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-cainjector-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cainjector-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cainjector-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cluster-view.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cluster-view.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-approve-cert-manager-io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-approve-cert-manager-io.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificates.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificates.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificatesigningrequests.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificatesigningrequests.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-challenges.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-challenges.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-clusterissuers.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-clusterissuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-ingress-shim.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-ingress-shim.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-issuers.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-issuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-orders.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-orders.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-edit.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-edit.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-view.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-view.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-webhook-subjectaccessreviews.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-webhook-subjectaccessreviews.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-cainjector.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-approve-cert-manager-io.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-approve-cert-manager-io.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificates.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificates.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificatesigningrequests.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificatesigningrequests.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-challenges.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-challenges.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-clusterissuers.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-clusterissuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-ingress-shim.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-ingress-shim.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-issuers.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-issuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-orders.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-orders.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-webhook-subjectaccessreviews.yaml
+++ b/manifests/dev/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-webhook-subjectaccessreviews.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cilium/apps_v1_daemonset_cilium-envoy.yaml
+++ b/manifests/dev/infrastructure/controllers/cilium/apps_v1_daemonset_cilium-envoy.yaml
@@ -14,7 +14,6 @@ spec:
       k8s-app: cilium-envoy
   template:
     metadata:
-      annotations: null
       labels:
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium

--- a/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_hubble-relay.yaml
+++ b/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_hubble-relay.yaml
@@ -83,7 +83,6 @@ spec:
           readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: null
       restartPolicy: Always
       securityContext:
         fsGroup: 65532

--- a/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_hubble-ui.yaml
+++ b/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_hubble-ui.yaml
@@ -60,10 +60,8 @@ spec:
         - containerPort: 8090
           name: grpc
         terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts: null
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: null
       securityContext:
         fsGroup: 1001
         runAsGroup: 1001

--- a/manifests/dev/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cnpg-mutating-webhook-configuration.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cnpg-mutating-webhook-configuration.yaml
@@ -3,10 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cnpg-validating-webhook-configuration.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cnpg-validating-webhook-configuration.yaml
@@ -3,10 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/cnpg/apps_v1_deployment_cnpg-cloudnative-pg.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/apps_v1_deployment_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
   namespace: cnpg-system
 spec:

--- a/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-edit.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-edit.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg-edit
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-view.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-view.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg-view
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrolebinding_cnpg-cloudnative-pg.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrolebinding_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/cnpg/v1_configmap_cnpg-controller-manager-config.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/v1_configmap_cnpg-controller-manager-config.yaml
@@ -4,9 +4,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-controller-manager-config
   namespace: cnpg-system

--- a/manifests/dev/infrastructure/controllers/cnpg/v1_configmap_cnpg-default-monitoring.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/v1_configmap_cnpg-default-monitoring.yaml
@@ -452,10 +452,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
     cnpg.io/reload: ""
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-default-monitoring
   namespace: cnpg-system

--- a/manifests/dev/infrastructure/controllers/cnpg/v1_service_cnpg-webhook-service.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/v1_service_cnpg-webhook-service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-webhook-service
   namespace: cnpg-system
 spec:

--- a/manifests/dev/infrastructure/controllers/cnpg/v1_serviceaccount_cnpg-cloudnative-pg.yaml
+++ b/manifests/dev/infrastructure/controllers/cnpg/v1_serviceaccount_cnpg-cloudnative-pg.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
   namespace: cnpg-system

--- a/manifests/dev/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane-rbac-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane-rbac-manager
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane-rbac-manager
   namespace: crossplane-system
@@ -31,11 +28,8 @@ spec:
         app: crossplane-rbac-manager
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.18.2
-        helm.sh/chart: crossplane-1.18.2
         release: crossplane
     spec:
       containers:

--- a/manifests/dev/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane
   namespace: crossplane-system
@@ -31,11 +28,8 @@ spec:
         app: crossplane
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.18.2
-        helm.sh/chart: crossplane-1.18.2
         release: crossplane
     spec:
       containers:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-admin.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-admin.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-admin

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-admin.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-admin.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-admin: "true"
   name: crossplane:aggregate-to-admin
 rules:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-browse.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-browse.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-browse: "true"
   name: crossplane:aggregate-to-browse
 rules:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-edit.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-edit.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-edit: "true"
   name: crossplane:aggregate-to-edit
 rules:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-view.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-view.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-view: "true"
   name: crossplane:aggregate-to-view
 rules:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-allowed-provider-permissions.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-allowed-provider-permissions.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane:allowed-provider-permissions

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-browse.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-browse.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-browse

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-edit.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-edit.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-edit

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-rbac-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-rbac-manager
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-system-aggregate-to-crossplane.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-system-aggregate-to-crossplane.yaml
@@ -5,12 +5,9 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-crossplane: "true"
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-view.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-view.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-view

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-admin.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-admin.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-rbac-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/crossplane/v1_service_crossplane-webhooks.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/v1_service_crossplane-webhooks.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane-webhooks
   namespace: crossplane-system

--- a/manifests/dev/infrastructure/controllers/crossplane/v1_serviceaccount_crossplane.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/v1_serviceaccount_crossplane.yaml
@@ -5,10 +5,7 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane
   namespace: crossplane-system

--- a/manifests/dev/infrastructure/controllers/crossplane/v1_serviceaccount_rbac-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/crossplane/v1_serviceaccount_rbac-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: rbac-manager
   namespace: crossplane-system

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/apps_v1_deployment_envoy-gateway.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/apps_v1_deployment_envoy-gateway.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system
 spec:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/batch_v1_job_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/batch_v1_job_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install, pre-upgrade
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 spec:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 rules:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-infra-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-infra-manager.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-infra-manager
   namespace: envoy-gateway-system
 rules:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-leader-election-role.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-leader-election-role.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-leader-election-role
   namespace: envoy-gateway-system
 rules:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-infra-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-infra-manager.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-infra-manager
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-leader-election-rolebinding.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-leader-election-rolebinding.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-leader-election-rolebinding
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/v1_configmap_envoy-gateway-config.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/v1_configmap_envoy-gateway-config.yaml
@@ -29,9 +29,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-config
   namespace: envoy-gateway-system

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/v1_service_envoy-gateway.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/v1_service_envoy-gateway.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system
 spec:

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,9 +5,6 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system

--- a/manifests/dev/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway.yaml
+++ b/manifests/dev/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system

--- a/manifests/dev/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_externalsecret-validate.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_externalsecret-validate.yaml
@@ -5,11 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: externalsecret-validate
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_secretstore-validate.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_secretstore-validate.yaml
@@ -5,11 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: secretstore-validate
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets-webhook.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:
@@ -20,10 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.13.0
-        helm.sh/chart: external-secrets-0.13.0
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/dev/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets
   namespace: external-secrets
 spec:
@@ -20,10 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.13.0
-        helm.sh/chart: external-secrets-0.13.0
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/dev/infrastructure/controllers/external-secrets/cert-manager.io_v1_certificate_external-secrets-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/cert-manager.io_v1_certificate_external-secrets-webhook.yaml
@@ -3,11 +3,8 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-cert-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-cert-controller-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-cert-controller-metrics
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-metrics
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-webhook-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-webhook-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook-metrics
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-controller
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-edit.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-edit.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-servicebindings.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-servicebindings.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-view.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-view.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_external-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_external-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_role_external-secrets-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_role_external-secrets-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-leaderelection
   namespace: external-secrets
 rules:

--- a/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_rolebinding_external-secrets-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_rolebinding_external-secrets-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-leaderelection
   namespace: external-secrets
 roleRef:

--- a/manifests/dev/infrastructure/controllers/external-secrets/v1_service_external-secrets-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/v1_service_external-secrets-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-metrics
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/v1_service_external-secrets-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/v1_service_external-secrets-webhook.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:

--- a/manifests/dev/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets-webhook.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets

--- a/manifests/dev/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets.yaml
+++ b/manifests/dev/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets
   namespace: external-secrets

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: admissionreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: backgroundscanreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_cleanuppolicies.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_cleanuppolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: cleanuppolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusteradmissionreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterbackgroundscanreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clustercleanuppolicies.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clustercleanuppolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clustercleanuppolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterephemeralreports.reports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterephemeralreports.reports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterephemeralreports.reports.kyverno.io
 spec:
   group: reports.kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterpolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_ephemeralreports.reports.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_ephemeralreports.reports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: ephemeralreports.reports.kyverno.io
 spec:
   group: reports.kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_globalcontextentries.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_globalcontextentries.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: globalcontextentries.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyexceptions.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyexceptions.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policyexceptions.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: updaterequests.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: admission-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: background-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: cleanup-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: reports-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-admission-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-admission-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-admission-reports
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-admission-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-admission-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-cluster-admission-reports
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-ephemeral-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-ephemeral-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-cluster-ephemeral-reports
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-ephemeral-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-ephemeral-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-ephemeral-reports
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-clean-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-clean-reports.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-clean-reports
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-migrate-resources
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-remove-configmap.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-remove-configmap
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-scale-to-zero
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller-core.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller:core
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller-core.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller:core
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller-core.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller:core
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-jobs.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-jobs.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-jobs
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-migrate-resources.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:migrate-resources
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policies.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policies.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:policies
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policyreports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policyreports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:policyreports
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:reports
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-updaterequests.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-updaterequests.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:updaterequests
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policies.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policies.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:policies
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policyreports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policyreports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:policyreports
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-reports.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:reports
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-updaterequests.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-updaterequests.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:updaterequests
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller-core.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller:core
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-jobs.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-jobs.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-jobs
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-migrate-resources.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:migrate-resources
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
   namespace: kyverno
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
   namespace: kyverno
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
   namespace: kyverno
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-remove-configmap.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:remove-configmap
   namespace: kyverno
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
   namespace: kyverno
 rules:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
   namespace: kyverno
 roleRef:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
   namespace: kyverno
 roleRef:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
   namespace: kyverno
 roleRef:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-remove-configmap.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:remove-configmap
   namespace: kyverno
 roleRef:

--- a/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
   namespace: kyverno
 roleRef:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: config
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-metrics
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_configmap_kyverno.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_configmap_kyverno.yaml
@@ -61,9 +61,6 @@ metadata:
   labels:
     app.kubernetes.io/component: config
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-liveness.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-liveness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-liveness
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-readiness.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-readiness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-readiness
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-liveness
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-readiness
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-background-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-background-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-reports-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-reports-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-svc-metrics
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-svc.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_service_kyverno-svc.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-svc
   namespace: kyverno
 spec:

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-admission-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-admission-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-background-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-background-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-jobs.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-jobs.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-jobs
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-migrate-resources.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-migrate-resources.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-migrate-resources
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-remove-configmap.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-remove-configmap.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-remove-configmap
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-reports-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-reports-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mariadb-operator-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     k8s.mariadb.com/webhook: ""
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_mariadb-operator-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     k8s.mariadb.com/webhook: ""
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-cert-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-cert-controller.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-cert-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-cert-controller.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-cert-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-cert-controller-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-cert-controller-cert-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-cert-controller-cert-controller.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller-cert-controller
   namespace: mariadb-system

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-webhook.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-webhook.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system

--- a/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator.yaml
+++ b/manifests/dev/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/apps_v1_deployment_sealed-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/apps_v1_deployment_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system
 spec:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrole_secrets-unsealer.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrole_secrets-unsealer.yaml
@@ -3,11 +3,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: secrets-unsealer
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_sealed-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-key-admin.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-key-admin.yaml
@@ -3,11 +3,8 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-key-admin
   namespace: kube-system
 rules:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-service-proxier.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-service-proxier.yaml
@@ -3,11 +3,8 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-service-proxier
   namespace: kube-system
 rules:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-key-admin.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-key-admin.yaml
@@ -3,11 +3,8 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-key-admin
   namespace: kube-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-service-proxier.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-service-proxier.yaml
@@ -3,11 +3,8 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-service-proxier
   namespace: kube-system
 roleRef:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-metrics
   namespace: kube-system
 spec:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system
 spec:

--- a/manifests/dev/infrastructure/controllers/sealed-secrets/v1_serviceaccount_sealed-secrets-controller.yaml
+++ b/manifests/dev/infrastructure/controllers/sealed-secrets/v1_serviceaccount_sealed-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system

--- a/manifests/dev/infrastructure/controllers/trust-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_trust-manager.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 webhooks:
 - admissionReviewVersions:

--- a/manifests/dev/infrastructure/controllers/trust-manager/apiextensions.k8s.io_v1_customresourcedefinition_bundles.trust.cert-manager.io.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/apiextensions.k8s.io_v1_customresourcedefinition_bundles.trust.cert-manager.io.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: bundles.trust.cert-manager.io
 spec:
   group: trust.cert-manager.io

--- a/manifests/dev/infrastructure/controllers/trust-manager/apps_v1_deployment_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/apps_v1_deployment_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:
@@ -19,10 +16,7 @@ spec:
       labels:
         app: trust-manager
         app.kubernetes.io/instance: trust-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: trust-manager
-        app.kubernetes.io/version: v0.15.0
-        helm.sh/chart: trust-manager-v0.15.0
     spec:
       containers:
       - args:

--- a/manifests/dev/infrastructure/controllers/trust-manager/cert-manager.io_v1_certificate_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/cert-manager.io_v1_certificate_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/trust-manager/cert-manager.io_v1_issuer_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/cert-manager.io_v1_issuer_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/trust-manager/monitoring.coreos.com_v1_servicemonitor_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/monitoring.coreos.com_v1_servicemonitor_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
     prometheus: default
   name: trust-manager
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/trust-manager/policy_v1_poddisruptionbudget_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/policy_v1_poddisruptionbudget_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrole_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrole_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager:leaderelection
   namespace: cert-manager
 rules:

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 rules:

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager-leaderelection.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager:leaderelection
   namespace: cert-manager
 roleRef:

--- a/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 roleRef:

--- a/manifests/dev/infrastructure/controllers/trust-manager/v1_service_trust-manager-metrics.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/v1_service_trust-manager-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager-metrics
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/trust-manager/v1_service_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/v1_service_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/dev/infrastructure/controllers/trust-manager/v1_serviceaccount_trust-manager.yaml
+++ b/manifests/dev/infrastructure/controllers/trust-manager/v1_serviceaccount_trust-manager.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager

--- a/manifests/dev/infrastructure/controllers/velero/apps_v1_deployment_velero.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/apps_v1_deployment_velero.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    app.kubernetes.io/version: 1.15.2
     component: velero
-    helm.sh/chart: velero-8.3.0
   name: velero
   namespace: velero
 spec:
@@ -26,10 +23,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/instance: velero
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: velero
-        app.kubernetes.io/version: 1.15.2
-        helm.sh/chart: velero-8.3.0
         name: velero
     spec:
       containers:

--- a/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_clusterrolebinding_velero-server.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_clusterrolebinding_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_role_velero-server.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_role_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero
 rules:

--- a/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_rolebinding_velero-server.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_rolebinding_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero
 roleRef:

--- a/manifests/dev/infrastructure/controllers/velero/v1_service_velero.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/v1_service_velero.yaml
@@ -3,9 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero
   namespace: velero
 spec:

--- a/manifests/dev/infrastructure/controllers/velero/v1_serviceaccount_velero-server.yaml
+++ b/manifests/dev/infrastructure/controllers/velero/v1_serviceaccount_velero-server.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-applicationset-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 spec:
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: applicationset-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-applicationset-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: dex-server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-dex-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 spec:
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: notifications-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-notifications-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-redis.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-redis.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis
   namespace: argocd
 spec:
@@ -22,11 +19,8 @@ spec:
       labels:
         app.kubernetes.io/component: redis
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-redis
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: repo-server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-repo-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 spec:
@@ -27,11 +24,8 @@ spec:
       labels:
         app.kubernetes.io/component: application-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-application-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/dev/infrastructure/gitops/argocd_batch_v1_job_argocd-redis-secret-init.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_batch_v1_job_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-applicationset-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-redis-secret-init.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-repo-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 rules: null

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 rules:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-applicationset-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-redis-secret-init.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 roleRef:
@@ -21,3 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-secret-init
+  namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-repo-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 roleRef:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-cm.yaml
@@ -165,10 +165,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-cmd-params-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-cmd-params-cm.yaml
@@ -39,10 +39,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-cmd-params-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-cmd-params-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-gpg-keys-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-gpg-keys-cm.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-gpg-keys-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-notifications-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-notifications-cm.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-rbac-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-rbac-cm.yaml
@@ -9,10 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-rbac-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-redis-health-configmap.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-redis-health-configmap.yaml
@@ -31,10 +31,7 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-health-configmap
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-ssh-known-hosts-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-ssh-known-hosts-cm.yaml
@@ -19,10 +19,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-ssh-known-hosts-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-ssh-known-hosts-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-tls-certs-cm.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_configmap_argocd-tls-certs-cm.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-tls-certs-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-tls-certs-cm
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_secret_argocd-notifications-secret.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_secret_argocd-notifications-secret.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-secret
   namespace: argocd
 stringData: null

--- a/manifests/dev/infrastructure/gitops/argocd_v1_secret_argocd-secret.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_secret_argocd-secret.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-secret
   namespace: argocd
 type: Opaque

--- a/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-applicationset-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-redis.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-redis.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-repo-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_service_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 spec:

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-application-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-applicationset-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-applicationset-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-dex-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-notifications-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-redis-secret-init.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-redis-secret-init.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-repo-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-repo-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_v1_serviceaccount_argocd-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
 rules:
 - apiGroups:

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-application-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-notifications-controller.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-server.yaml
+++ b/manifests/dev/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:
@@ -25,13 +22,9 @@ spec:
       annotations:
         checksum/configmap-env-vars: 5063be6ef5fad5527ad98fe384832ce3752f6f1e4a682077d42f0032dc41cc47
       labels:
-        app.kubernetes.io/app-version: 26.1.0
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/instance: keycloak
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.1.0
-        helm.sh/chart: keycloak-24.4.6
     spec:
       affinity:
         nodeAffinity: null

--- a/manifests/dev/platform/idp/keycloak_monitoring.coreos.com_v1_servicemonitor_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_monitoring.coreos.com_v1_servicemonitor_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_networking.k8s.io_v1_networkpolicy_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_networking.k8s.io_v1_networkpolicy_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_policy_v1_poddisruptionbudget_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_policy_v1_poddisruptionbudget_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_v1_configmap_keycloak-env-vars.yaml
+++ b/manifests/dev/platform/idp/keycloak_v1_configmap_keycloak-env-vars.yaml
@@ -16,9 +16,6 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-env-vars
   namespace: keycloak

--- a/manifests/dev/platform/idp/keycloak_v1_service_keycloak-headless.yaml
+++ b/manifests/dev/platform/idp/keycloak_v1_service_keycloak-headless.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-headless
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_v1_service_keycloak-metrics.yaml
+++ b/manifests/dev/platform/idp/keycloak_v1_service_keycloak-metrics.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-metrics
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_v1_service_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_v1_service_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/dev/platform/idp/keycloak_v1_serviceaccount_keycloak.yaml
+++ b/manifests/dev/platform/idp/keycloak_v1_serviceaccount_keycloak.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak

--- a/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
+++ b/manifests/dev/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/manifests/dev/platform/monitoring/kube-system_rbac.authorization.k8s.io_v1_rolebinding_prometheus-adapter-auth-reader.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_rbac.authorization.k8s.io_v1_rolebinding_prometheus-adapter-auth-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-auth-reader
   namespace: kube-system
 roleRef:

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: coredns
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-controller-manager
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-etcd
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-proxy
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-scheduler
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_daemonset_node-exporter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/part-of: prometheus-node-exporter
-        app.kubernetes.io/version: 1.8.2
-        helm.sh/chart: prometheus-node-exporter-4.43.1
         jobLabel: node-exporter
         release: kube-prometheus-stack
     spec:

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:
@@ -27,8 +25,6 @@ spec:
       labels:
         app.kubernetes.io/instance: kube-prometheus-stack
         app.kubernetes.io/name: grafana
-        app.kubernetes.io/version: 11.4.0
-        helm.sh/chart: grafana-8.8.4
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-state-metrics
-        app.kubernetes.io/version: 2.14.0
-        helm.sh/chart: kube-state-metrics-5.28.0
         release: kube-prometheus-stack
     spec:
       automountServiceAccountToken: true

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-adapter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-adapter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring
 spec:
@@ -29,11 +26,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: prometheus-adapter
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: prometheus-adapter
-        app.kubernetes.io/version: v0.12.0
-        helm.sh/chart: prometheus-adapter-4.11.0
       name: prometheus-adapter
     spec:
       affinity: {}

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
@@ -27,11 +24,8 @@ spec:
         app: kube-prometheus-stack-operator
         app.kubernetes.io/component: prometheus-operator
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
         app.kubernetes.io/part-of: kube-prometheus-stack
-        app.kubernetes.io/version: 68.3.0
-        chart: kube-prometheus-stack-68.3.0
         heritage: Helm
         release: kube-prometheus-stack
     spec:

--- a/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission-create
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-create

--- a/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission-patch
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-patch

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-config-reloaders

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-general.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-cpu-usage-seconds-total

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-cache

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-rss

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-swap

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-working-set-bytes

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-resource

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.pod-owner

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-availability.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-burnrate.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-histogram.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-slos

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-general.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-node-recording.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-state-metrics

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-apps

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-resources

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-storage

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-apiserver

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-controller-manager

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kube-proxy

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kubelet

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-scheduler

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-network

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node.rules

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus-operator

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-apiserver
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-coredns

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-etcd

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-proxy

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kubelet
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 rules: []

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 roleRef:

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana-config-dashboards.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana-config-dashboards.yaml
@@ -19,7 +19,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-config-dashboards
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana-test.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana-test.yaml
@@ -15,7 +15,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_grafana.yaml
@@ -36,7 +36,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
@@ -31,10 +31,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
@@ -71,10 +71,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
@@ -105,10 +105,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
@@ -45,10 +45,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
@@ -53,10 +53,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
@@ -25,10 +25,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_datasource: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
@@ -28,10 +28,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
@@ -77,10 +77,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
@@ -161,10 +161,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
@@ -60,10 +60,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
@@ -163,10 +163,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
@@ -57,10 +57,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
@@ -150,10 +150,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
@@ -164,10 +164,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
@@ -171,10 +171,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
@@ -102,10 +102,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
@@ -78,10 +78,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
@@ -110,10 +110,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
@@ -595,10 +595,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
@@ -34,10 +34,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
@@ -55,10 +55,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
@@ -63,10 +63,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
@@ -59,10 +59,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
@@ -42,10 +42,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
@@ -35,10 +35,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
@@ -44,10 +44,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
@@ -47,10 +47,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
@@ -56,10 +56,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
@@ -62,10 +62,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_prometheus-adapter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_prometheus-adapter.yaml
@@ -46,10 +46,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_pod_grafana-test.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_pod_grafana-test.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring
 spec:

--- a/manifests/dev/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: alertmanager-k8s

--- a/manifests/dev/platform/monitoring/monitoring_v1_secret_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_secret_grafana.yaml
@@ -8,8 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 type: Opaque

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_kube-state-metrics.yaml
@@ -6,11 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_node-exporter.yaml
@@ -6,11 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     jobLabel: node-exporter
     release: kube-prometheus-stack
   name: node-exporter

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-adapter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-adapter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_grafana-test.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_grafana-test.yaml
@@ -7,7 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_grafana.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_grafana.yaml
@@ -5,7 +5,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
@@ -9,11 +9,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-alertmanager
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_kube-state-metrics.yaml
@@ -5,11 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_node-exporter.yaml
@@ -5,11 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-adapter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-adapter.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_grafana-clusterrole.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_grafana-clusterrole.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-clusterrole
 rules:
 - apiGroups:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
 rules:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-metrics.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-metrics
 rules:
 - apiGroups:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-resource-reader.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-resource-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-resource-reader
 rules:
 - apiGroups:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_grafana-clusterrolebinding.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_grafana-clusterrolebinding.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
 roleRef:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-hpa-controller-metrics.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-hpa-controller-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-hpa-controller-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-resource-reader.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-resource-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-resource-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-system-auth-delegator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-system-auth-delegator.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-system-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/production/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cert-manager-webhook.yaml
@@ -7,10 +7,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cert-manager-webhook.yaml
@@ -7,10 +7,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: certificaterequests.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificates.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_certificates.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: certificates.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: challenges.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_clusterissuers.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_clusterissuers.cert-manager.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: clusterissuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_issuers.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_issuers.cert-manager.io.yaml
@@ -7,10 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: issuers.cert-manager.io
 spec:
   group: cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_orders.acme.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/apiextensions.k8s.io_v1_customresourcedefinition_orders.acme.cert-manager.io.yaml
@@ -7,10 +7,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: orders.acme.cert-manager.io
 spec:
   group: acme.cert-manager.io

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: cainjector
         app.kubernetes.io/component: cainjector
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_apps_v1_deployment_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:
@@ -24,10 +21,7 @@ spec:
         app: cert-manager
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: cert-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.16.3
-        helm.sh/chart: cert-manager-v1.16.3
     spec:
       containers:
       - args:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_monitoring.coreos.com_v1_servicemonitor_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_monitoring.coreos.com_v1_servicemonitor_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     prometheus: default
   name: cert-manager
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_policy_v1_poddisruptionbudget_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-startupapicheck-create-cert.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-startupapicheck-create-cert.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck:create-cert
   namespace: cert-manager
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-tokenrequest.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-tokenrequest.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-tokenrequest
   namespace: cert-manager
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-webhook-dynamic-serving.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_role_cert-manager-webhook-dynamic-serving.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cert-manager-tokenrequest.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cert-manager-tokenrequest.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cert-manager-tokenrequest
   namespace: cert-manager
 roleRef:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-startupapicheck-create-cert.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-startupapicheck-create-cert.yaml
@@ -9,10 +9,7 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck:create-cert
   namespace: cert-manager
 roleRef:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-webhook-dynamic-serving.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-webhook-dynamic-serving.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:dynamic-serving
   namespace: cert-manager
 roleRef:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_configmap_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_configmap_cert-manager.yaml
@@ -10,9 +10,6 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_service_cert-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-cainjector.yaml
@@ -6,9 +6,6 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-startupapicheck.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-startupapicheck.yaml
@@ -10,9 +10,6 @@ metadata:
     app: startupapicheck
     app.kubernetes.io/component: startupapicheck
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-startupapicheck
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager-webhook.yaml
@@ -6,9 +6,6 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/cert-manager_v1_serviceaccount_cert-manager.yaml
@@ -6,9 +6,6 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-cainjector-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-cainjector-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_role_cert-manager-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager:leaderelection
   namespace: kube-system
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cainjector-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-cainjector-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector:leaderelection
   namespace: kube-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/kube-system_rbac.authorization.k8s.io_v1_rolebinding_cert-manager-leaderelection.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager:leaderelection
   namespace: kube-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cluster-view.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-cluster-view.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: cert-manager-cluster-view
 rules:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-approve-cert-manager-io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-approve-cert-manager-io.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-approve:cert-manager-io
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificates.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificates.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificates
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificatesigningrequests.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-certificatesigningrequests.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificatesigningrequests
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-challenges.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-challenges.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-challenges
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-clusterissuers.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-clusterissuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-clusterissuers
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-ingress-shim.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-ingress-shim.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-ingress-shim
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-issuers.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-issuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-issuers
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-orders.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-controller-orders.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-orders
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-edit.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-edit.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: cert-manager-edit

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-view.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-view.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-webhook-subjectaccessreviews.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrole_cert-manager-webhook-subjectaccessreviews.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:subjectaccessreviews
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-cainjector.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-cainjector.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cainjector
     app.kubernetes.io/component: cainjector
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-cainjector
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-approve-cert-manager-io.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-approve-cert-manager-io.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-approve:cert-manager-io
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificates.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificates.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificates
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificatesigningrequests.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-certificatesigningrequests.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: cert-manager
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-certificatesigningrequests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-challenges.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-challenges.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-challenges
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-clusterissuers.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-clusterissuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-clusterissuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-ingress-shim.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-ingress-shim.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-ingress-shim
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-issuers.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-issuers.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-issuers
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-orders.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-controller-orders.yaml
@@ -5,10 +5,7 @@ metadata:
     app: cert-manager
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-controller-orders
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-webhook-subjectaccessreviews.yaml
+++ b/manifests/production/infrastructure/controllers/cert-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_cert-manager-webhook-subjectaccessreviews.yaml
@@ -5,10 +5,7 @@ metadata:
     app: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: cert-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.16.3
-    helm.sh/chart: cert-manager-v1.16.3
   name: cert-manager-webhook:subjectaccessreviews
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cilium/apps_v1_daemonset_cilium-envoy.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/apps_v1_daemonset_cilium-envoy.yaml
@@ -14,7 +14,6 @@ spec:
       k8s-app: cilium-envoy
   template:
     metadata:
-      annotations: null
       labels:
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/infrastructure/controllers/cilium/apps_v1_deployment_hubble-relay.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/apps_v1_deployment_hubble-relay.yaml
@@ -83,7 +83,6 @@ spec:
           readOnly: true
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: null
       restartPolicy: Always
       securityContext:
         fsGroup: 65532

--- a/manifests/production/infrastructure/controllers/cilium/apps_v1_deployment_hubble-ui.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/apps_v1_deployment_hubble-ui.yaml
@@ -60,10 +60,8 @@ spec:
         - containerPort: 8090
           name: grpc
         terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts: null
       nodeSelector:
         kubernetes.io/os: linux
-      priorityClassName: null
       securityContext:
         fsGroup: 1001
         runAsGroup: 1001

--- a/manifests/production/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cnpg-mutating-webhook-configuration.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_cnpg-mutating-webhook-configuration.yaml
@@ -3,10 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cnpg-validating-webhook-configuration.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_cnpg-validating-webhook-configuration.yaml
@@ -3,10 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/cnpg/apps_v1_deployment_cnpg-cloudnative-pg.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/apps_v1_deployment_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
   namespace: cnpg-system
 spec:

--- a/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-edit.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-edit.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg-edit
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-view.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg-view.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg-view
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrole_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrolebinding_cnpg-cloudnative-pg.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/rbac.authorization.k8s.io_v1_clusterrolebinding_cnpg-cloudnative-pg.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/cnpg/v1_configmap_cnpg-controller-manager-config.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/v1_configmap_cnpg-controller-manager-config.yaml
@@ -4,9 +4,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-controller-manager-config
   namespace: cnpg-system

--- a/manifests/production/infrastructure/controllers/cnpg/v1_configmap_cnpg-default-monitoring.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/v1_configmap_cnpg-default-monitoring.yaml
@@ -452,10 +452,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
     cnpg.io/reload: ""
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-default-monitoring
   namespace: cnpg-system

--- a/manifests/production/infrastructure/controllers/cnpg/v1_service_cnpg-webhook-service.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/v1_service_cnpg-webhook-service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-webhook-service
   namespace: cnpg-system
 spec:

--- a/manifests/production/infrastructure/controllers/cnpg/v1_serviceaccount_cnpg-cloudnative-pg.yaml
+++ b/manifests/production/infrastructure/controllers/cnpg/v1_serviceaccount_cnpg-cloudnative-pg.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: cnpg
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cloudnative-pg
-    app.kubernetes.io/version: 1.25.0
-    helm.sh/chart: cloudnative-pg-0.23.0
   name: cnpg-cloudnative-pg
   namespace: cnpg-system

--- a/manifests/production/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane-rbac-manager.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane-rbac-manager
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane-rbac-manager
   namespace: crossplane-system
@@ -31,11 +28,8 @@ spec:
         app: crossplane-rbac-manager
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.18.2
-        helm.sh/chart: crossplane-1.18.2
         release: crossplane
     spec:
       containers:

--- a/manifests/production/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/apps_v1_deployment_crossplane.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane
   namespace: crossplane-system
@@ -31,11 +28,8 @@ spec:
         app: crossplane
         app.kubernetes.io/component: cloud-infrastructure-controller
         app.kubernetes.io/instance: crossplane
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: crossplane
         app.kubernetes.io/part-of: crossplane
-        app.kubernetes.io/version: 1.18.2
-        helm.sh/chart: crossplane-1.18.2
         release: crossplane
     spec:
       containers:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-admin.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-admin.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-admin

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-admin.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-admin.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-admin: "true"
   name: crossplane:aggregate-to-admin
 rules:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-browse.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-browse.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-browse: "true"
   name: crossplane:aggregate-to-browse
 rules:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-edit.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-edit.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-edit: "true"
   name: crossplane:aggregate-to-edit
 rules:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-view.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-aggregate-to-view.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-view: "true"
   name: crossplane:aggregate-to-view
 rules:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-allowed-provider-permissions.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-allowed-provider-permissions.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane:allowed-provider-permissions

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-browse.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-browse.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-browse

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-edit.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-edit.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-edit

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-rbac-manager.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-rbac-manager
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-system-aggregate-to-crossplane.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-system-aggregate-to-crossplane.yaml
@@ -5,12 +5,9 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
     crossplane.io/scope: system
-    helm.sh/chart: crossplane-1.18.2
     rbac.crossplane.io/aggregate-to-crossplane: "true"
   name: crossplane:system:aggregate-to-crossplane
 rules:

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-view.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane-view.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-view

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrole_crossplane.yaml
@@ -9,9 +9,6 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-admin.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-admin.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-rbac-manager.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane-rbac-manager.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane-rbac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/rbac.authorization.k8s.io_v1_clusterrolebinding_crossplane.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/crossplane/v1_service_crossplane-webhooks.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/v1_service_crossplane-webhooks.yaml
@@ -5,11 +5,8 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
     release: crossplane
   name: crossplane-webhooks
   namespace: crossplane-system

--- a/manifests/production/infrastructure/controllers/crossplane/v1_serviceaccount_crossplane.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/v1_serviceaccount_crossplane.yaml
@@ -5,10 +5,7 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: crossplane
   namespace: crossplane-system

--- a/manifests/production/infrastructure/controllers/crossplane/v1_serviceaccount_rbac-manager.yaml
+++ b/manifests/production/infrastructure/controllers/crossplane/v1_serviceaccount_rbac-manager.yaml
@@ -5,10 +5,7 @@ metadata:
     app: crossplane
     app.kubernetes.io/component: cloud-infrastructure-controller
     app.kubernetes.io/instance: crossplane
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: crossplane
     app.kubernetes.io/part-of: crossplane
-    app.kubernetes.io/version: 1.18.2
-    helm.sh/chart: crossplane-1.18.2
   name: rbac-manager
   namespace: crossplane-system

--- a/manifests/production/infrastructure/controllers/envoy-gateway/apps_v1_deployment_envoy-gateway.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/apps_v1_deployment_envoy-gateway.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system
 spec:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/batch_v1_job_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/batch_v1_job_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install, pre-upgrade
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 spec:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 rules:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-infra-manager.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-infra-manager.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-infra-manager
   namespace: envoy-gateway-system
 rules:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-leader-election-role.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_role_envoy-gateway-gateway-helm-leader-election-role.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-leader-election-role
   namespace: envoy-gateway-system
 rules:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-infra-manager.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-infra-manager.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-infra-manager
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-leader-election-rolebinding.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/rbac.authorization.k8s.io_v1_rolebinding_envoy-gateway-gateway-helm-leader-election-rolebinding.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-leader-election-rolebinding
   namespace: envoy-gateway-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/v1_configmap_envoy-gateway-config.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/v1_configmap_envoy-gateway-config.yaml
@@ -29,9 +29,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-config
   namespace: envoy-gateway-system

--- a/manifests/production/infrastructure/controllers/envoy-gateway/v1_service_envoy-gateway.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/v1_service_envoy-gateway.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
     control-plane: envoy-gateway
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system
 spec:

--- a/manifests/production/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway-gateway-helm-certgen.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway-gateway-helm-certgen.yaml
@@ -5,9 +5,6 @@ metadata:
     helm.sh/hook: pre-install
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway-gateway-helm-certgen
   namespace: envoy-gateway-system

--- a/manifests/production/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway.yaml
+++ b/manifests/production/infrastructure/controllers/envoy-gateway/v1_serviceaccount_envoy-gateway.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: envoy-gateway
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway-helm
-    app.kubernetes.io/version: v1.2.5
-    helm.sh/chart: gateway-helm-1.2.5
   name: envoy-gateway
   namespace: envoy-gateway-system

--- a/manifests/production/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_externalsecret-validate.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_externalsecret-validate.yaml
@@ -5,11 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: externalsecret-validate
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_secretstore-validate.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_secretstore-validate.yaml
@@ -5,11 +5,8 @@ metadata:
     cert-manager.io/inject-ca-from: external-secrets/external-secrets-webhook
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: secretstore-validate
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets-webhook.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:
@@ -20,10 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets-webhook
-        app.kubernetes.io/version: v0.13.0
-        helm.sh/chart: external-secrets-0.13.0
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/production/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/apps_v1_deployment_external-secrets.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets
   namespace: external-secrets
 spec:
@@ -20,10 +17,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: external-secrets
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: external-secrets
-        app.kubernetes.io/version: v0.13.0
-        helm.sh/chart: external-secrets-0.13.0
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/production/infrastructure/controllers/external-secrets/cert-manager.io_v1_certificate_external-secrets-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/cert-manager.io_v1_certificate_external-secrets-webhook.yaml
@@ -3,11 +3,8 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-cert-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-cert-controller-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-cert-controller
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-cert-controller-metrics
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-metrics
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-webhook-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/monitoring.coreos.com_v1_servicemonitor_external-secrets-webhook-metrics.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook-metrics
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-controller
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-edit.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-edit.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: external-secrets-edit

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-servicebindings.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-servicebindings.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     servicebinding.io/controller: "true"
   name: external-secrets-servicebindings
 rules:

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-view.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrole_external-secrets-view.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_external-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_external-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_role_external-secrets-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_role_external-secrets-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-leaderelection
   namespace: external-secrets
 rules:

--- a/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_rolebinding_external-secrets-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/rbac.authorization.k8s.io_v1_rolebinding_external-secrets-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-leaderelection
   namespace: external-secrets
 roleRef:

--- a/manifests/production/infrastructure/controllers/external-secrets/v1_service_external-secrets-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/v1_service_external-secrets-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-metrics
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/v1_service_external-secrets-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/v1_service_external-secrets-webhook.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
     external-secrets.io/component: webhook
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets
 spec:

--- a/manifests/production/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets-webhook.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets-webhook
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets-webhook
   namespace: external-secrets

--- a/manifests/production/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/external-secrets/v1_serviceaccount_external-secrets.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: external-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: external-secrets
-    app.kubernetes.io/version: v0.13.0
-    helm.sh/chart: external-secrets-0.13.0
   name: external-secrets
   namespace: external-secrets

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_admissionreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: admissionreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_backgroundscanreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: backgroundscanreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_cleanuppolicies.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_cleanuppolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: cleanuppolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusteradmissionreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusteradmissionreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterbackgroundscanreports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterbackgroundscanreports.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clustercleanuppolicies.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clustercleanuppolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clustercleanuppolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterephemeralreports.reports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterephemeralreports.reports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterephemeralreports.reports.kyverno.io
 spec:
   group: reports.kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterpolicies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_clusterpolicyreports.wgpolicyk8s.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: clusterpolicyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_ephemeralreports.reports.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_ephemeralreports.reports.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: ephemeralreports.reports.kyverno.io
 spec:
   group: reports.kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_globalcontextentries.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_globalcontextentries.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: globalcontextentries.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policies.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policies.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyexceptions.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyexceptions.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policyexceptions.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_policyreports.wgpolicyk8s.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: policyreports.wgpolicyk8s.io
 spec:
   group: wgpolicyk8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apiextensions.k8s.io_v1_customresourcedefinition_updaterequests.kyverno.io.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: crds
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno-crds
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: crds-3.2.7
   name: updaterequests.kyverno.io
 spec:
   group: kyverno.io

--- a/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: admission-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: background-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: cleanup-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno
 spec:
@@ -28,10 +25,7 @@ spec:
       labels:
         app.kubernetes.io/component: reports-controller
         app.kubernetes.io/instance: kyverno
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: kyverno
-        app.kubernetes.io/version: 3.2.7
-        helm.sh/chart: kyverno-3.2.7
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-admission-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-admission-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-admission-reports
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-admission-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-admission-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-cluster-admission-reports
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-ephemeral-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-cluster-ephemeral-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-cluster-ephemeral-reports
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-ephemeral-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_cronjob_kyverno-cleanup-ephemeral-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-ephemeral-reports
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-clean-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-clean-reports.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-clean-reports
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-migrate-resources
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-remove-configmap.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-remove-configmap
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-scale-to-zero
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/monitoring.coreos.com_v1_servicemonitor_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller-core.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller:core
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-admission-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller-core.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller:core
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-background-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller-core.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller:core
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-jobs.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-cleanup-jobs.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-jobs
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-migrate-resources.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:migrate-resources
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policies.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policies.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:policies
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policyreports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-policyreports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:policyreports
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:reports
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-updaterequests.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-admin-updaterequests.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kyverno:rbac:admin:updaterequests
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policies.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policies.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:policies
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policyreports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-policyreports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:policyreports
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-reports.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-reports.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:reports
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-updaterequests.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-rbac-view-updaterequests.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kyverno:rbac:view:updaterequests
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller-core.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller-core.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller:core
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrole_kyverno-reports-controller.yaml
@@ -10,8 +10,5 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-jobs.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-cleanup-jobs.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-jobs
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-migrate-resources.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-migrate-resources.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:migrate-resources
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_clusterrolebinding_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
   namespace: kyverno
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
   namespace: kyverno
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
   namespace: kyverno
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-remove-configmap.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:remove-configmap
   namespace: kyverno
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_role_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
   namespace: kyverno
 rules:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-admission-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:admission-controller
   namespace: kyverno
 roleRef:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-background-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:background-controller
   namespace: kyverno
 roleRef:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:cleanup-controller
   namespace: kyverno
 roleRef:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-remove-configmap.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-remove-configmap.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:remove-configmap
   namespace: kyverno
 roleRef:

--- a/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/rbac.authorization.k8s.io_v1_rolebinding_kyverno-reports-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno:reports-controller
   namespace: kyverno
 roleRef:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_configmap_kyverno-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_configmap_kyverno-metrics.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: config
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-metrics
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_configmap_kyverno.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_configmap_kyverno.yaml
@@ -61,9 +61,6 @@ metadata:
   labels:
     app.kubernetes.io/component: config
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-liveness.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-liveness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-liveness
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-readiness.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-admission-controller-readiness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller-readiness
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-liveness
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-readiness
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/component: test
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-background-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-background-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-cleanup-controller.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-reports-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-reports-controller-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-svc-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-svc-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-svc-metrics
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-svc.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_service_kyverno-svc.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-svc
   namespace: kyverno
 spec:

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-admission-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-admission-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: admission-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-admission-controller
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-background-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-background-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: background-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-background-controller
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: cleanup-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-controller
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-jobs.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-cleanup-jobs.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-cleanup-jobs
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-migrate-resources.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-migrate-resources.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-migrate-resources
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-remove-configmap.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-remove-configmap.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/component: hooks
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-remove-configmap
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-reports-controller.yaml
+++ b/manifests/production/infrastructure/controllers/kyverno/v1_serviceaccount_kyverno-reports-controller.yaml
@@ -4,9 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/component: reports-controller
     app.kubernetes.io/instance: kyverno
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kyverno
-    app.kubernetes.io/version: 3.2.7
-    helm.sh/chart: kyverno-3.2.7
   name: kyverno-reports-controller
   namespace: kyverno

--- a/manifests/production/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_mariadb-operator-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     k8s.mariadb.com/webhook: ""
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_mariadb-operator-webhook.yaml
@@ -5,10 +5,7 @@ metadata:
     k8s.mariadb.com/webhook: ""
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-cert-controller.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-cert-controller.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-cert-controller.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-cert-controller.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/monitoring.coreos.com_v1_servicemonitor_mariadb-operator.yaml
@@ -3,10 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-cert-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-cert-controller-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook-metrics.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook-metrics
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_service_mariadb-operator-webhook.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system
 spec:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-cert-controller-cert-controller.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-cert-controller-cert-controller.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-cert-controller
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-cert-controller-cert-controller
   namespace: mariadb-system

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-webhook.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator-webhook.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator-webhook
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator-webhook
   namespace: mariadb-system

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_serviceaccount_mariadb-operator.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: mariadb-operator
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mariadb-operator
-    app.kubernetes.io/version: 0.36.0
-    helm.sh/chart: mariadb-operator-0.36.0
   name: mariadb-operator
   namespace: mariadb-system

--- a/manifests/production/infrastructure/controllers/sealed-secrets/apps_v1_deployment_sealed-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/apps_v1_deployment_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system
 spec:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrole_secrets-unsealer.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrole_secrets-unsealer.yaml
@@ -3,11 +3,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: secrets-unsealer
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_sealed-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_clusterrolebinding_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-key-admin.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-key-admin.yaml
@@ -3,11 +3,8 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-key-admin
   namespace: kube-system
 rules:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-service-proxier.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_role_sealed-secrets-controller-service-proxier.yaml
@@ -3,11 +3,8 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-service-proxier
   namespace: kube-system
 rules:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-key-admin.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-key-admin.yaml
@@ -3,11 +3,8 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-key-admin
   namespace: kube-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-service-proxier.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/rbac.authorization.k8s.io_v1_rolebinding_sealed-secrets-controller-service-proxier.yaml
@@ -3,11 +3,8 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-service-proxier
   namespace: kube-system
 roleRef:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller-metrics
   namespace: kube-system
 spec:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/v1_service_sealed-secrets-controller.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system
 spec:

--- a/manifests/production/infrastructure/controllers/sealed-secrets/v1_serviceaccount_sealed-secrets-controller.yaml
+++ b/manifests/production/infrastructure/controllers/sealed-secrets/v1_serviceaccount_sealed-secrets-controller.yaml
@@ -3,10 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: sealed-secrets
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: sealed-secrets
     app.kubernetes.io/part-of: sealed-secrets
-    app.kubernetes.io/version: 0.28.0
-    helm.sh/chart: sealed-secrets-2.17.1
   name: sealed-secrets-controller
   namespace: kube-system

--- a/manifests/production/infrastructure/controllers/trust-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_trust-manager.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 webhooks:
 - admissionReviewVersions:

--- a/manifests/production/infrastructure/controllers/trust-manager/apiextensions.k8s.io_v1_customresourcedefinition_bundles.trust.cert-manager.io.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/apiextensions.k8s.io_v1_customresourcedefinition_bundles.trust.cert-manager.io.yaml
@@ -5,10 +5,7 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: bundles.trust.cert-manager.io
 spec:
   group: trust.cert-manager.io

--- a/manifests/production/infrastructure/controllers/trust-manager/apps_v1_deployment_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/apps_v1_deployment_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:
@@ -19,10 +16,7 @@ spec:
       labels:
         app: trust-manager
         app.kubernetes.io/instance: trust-manager
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: trust-manager
-        app.kubernetes.io/version: v0.15.0
-        helm.sh/chart: trust-manager-v0.15.0
     spec:
       containers:
       - args:

--- a/manifests/production/infrastructure/controllers/trust-manager/cert-manager.io_v1_certificate_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/cert-manager.io_v1_certificate_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Certificate
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/trust-manager/cert-manager.io_v1_issuer_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/cert-manager.io_v1_issuer_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/trust-manager/monitoring.coreos.com_v1_servicemonitor_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/monitoring.coreos.com_v1_servicemonitor_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
     prometheus: default
   name: trust-manager
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/trust-manager/policy_v1_poddisruptionbudget_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/policy_v1_poddisruptionbudget_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrole_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrole_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_clusterrolebinding_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager:leaderelection
   namespace: cert-manager
 rules:

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_role_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 rules:

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager-leaderelection.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager-leaderelection.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager:leaderelection
   namespace: cert-manager
 roleRef:

--- a/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/rbac.authorization.k8s.io_v1_rolebinding_trust-manager.yaml
@@ -3,10 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 roleRef:

--- a/manifests/production/infrastructure/controllers/trust-manager/v1_service_trust-manager-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/v1_service_trust-manager-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager-metrics
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/trust-manager/v1_service_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/v1_service_trust-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: trust-manager
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager
 spec:

--- a/manifests/production/infrastructure/controllers/trust-manager/v1_serviceaccount_trust-manager.yaml
+++ b/manifests/production/infrastructure/controllers/trust-manager/v1_serviceaccount_trust-manager.yaml
@@ -3,9 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: trust-manager
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: trust-manager
-    app.kubernetes.io/version: v0.15.0
-    helm.sh/chart: trust-manager-v0.15.0
   name: trust-manager
   namespace: cert-manager

--- a/manifests/production/infrastructure/controllers/velero/apps_v1_deployment_velero.yaml
+++ b/manifests/production/infrastructure/controllers/velero/apps_v1_deployment_velero.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    app.kubernetes.io/version: 1.15.2
     component: velero
-    helm.sh/chart: velero-8.3.0
   name: velero
   namespace: velero
 spec:
@@ -26,10 +23,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/instance: velero
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: velero
-        app.kubernetes.io/version: 1.15.2
-        helm.sh/chart: velero-8.3.0
         name: velero
     spec:
       containers:

--- a/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_clusterrolebinding_velero-server.yaml
+++ b/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_clusterrolebinding_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_role_velero-server.yaml
+++ b/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_role_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero
 rules:

--- a/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_rolebinding_velero-server.yaml
+++ b/manifests/production/infrastructure/controllers/velero/rbac.authorization.k8s.io_v1_rolebinding_velero-server.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero
 roleRef:

--- a/manifests/production/infrastructure/controllers/velero/v1_service_velero.yaml
+++ b/manifests/production/infrastructure/controllers/velero/v1_service_velero.yaml
@@ -3,9 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero
   namespace: velero
 spec:

--- a/manifests/production/infrastructure/controllers/velero/v1_serviceaccount_velero-server.yaml
+++ b/manifests/production/infrastructure/controllers/velero/v1_serviceaccount_velero-server.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: velero
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: velero
-    helm.sh/chart: velero-8.3.0
   name: velero-server
   namespace: velero

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-applicationset-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 spec:
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: applicationset-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-applicationset-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: dex-server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-dex-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 spec:
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: notifications-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-notifications-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-redis.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-redis.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis
   namespace: argocd
 spec:
@@ -22,11 +19,8 @@ spec:
       labels:
         app.kubernetes.io/component: redis
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-redis
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: repo-server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-repo-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 spec:
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: server
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-server
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 spec:
@@ -27,11 +24,8 @@ spec:
       labels:
         app.kubernetes.io/component: application-controller
         app.kubernetes.io/instance: argocd
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: argocd-application-controller
         app.kubernetes.io/part-of: argocd
-        app.kubernetes.io/version: v2.13.3
-        helm.sh/chart: argo-cd-7.7.16
     spec:
       affinity:
         podAntiAffinity:

--- a/manifests/production/infrastructure/gitops/argocd_batch_v1_job_argocd-redis-secret-init.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_batch_v1_job_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-applicationset-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-redis-secret-init.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 rules: null

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_role_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 rules:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-applicationset-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-redis-secret-init.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-redis-secret-init.yaml
@@ -7,11 +7,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd
 roleRef:
@@ -21,3 +18,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argocd-redis-secret-init
+  namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_rbac.authorization.k8s.io_v1_rolebinding_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 roleRef:

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-cm.yaml
@@ -165,10 +165,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-cmd-params-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-cmd-params-cm.yaml
@@ -39,10 +39,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-cmd-params-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-cmd-params-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-gpg-keys-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-gpg-keys-cm.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-gpg-keys-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-gpg-keys-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-notifications-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-notifications-cm.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-rbac-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-rbac-cm.yaml
@@ -9,10 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-rbac-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-rbac-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-redis-health-configmap.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-redis-health-configmap.yaml
@@ -31,10 +31,7 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-health-configmap
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-ssh-known-hosts-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-ssh-known-hosts-cm.yaml
@@ -19,10 +19,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-ssh-known-hosts-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-ssh-known-hosts-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-tls-certs-cm.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_configmap_argocd-tls-certs-cm.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-tls-certs-cm
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-tls-certs-cm
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_secret_argocd-notifications-secret.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_secret_argocd-notifications-secret.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-secret
   namespace: argocd
 stringData: null

--- a/manifests/production/infrastructure/gitops/argocd_v1_secret_argocd-secret.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_secret_argocd-secret.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-secret
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-secret
   namespace: argocd
 type: Opaque

--- a/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-applicationset-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-applicationset-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-dex-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-redis.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-redis.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: redis
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-repo-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_service_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd
 spec:

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-application-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-applicationset-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-applicationset-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: applicationset-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-applicationset-controller
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-dex-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-dex-server
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-notifications-controller.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-redis-secret-init.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-redis-secret-init.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/component: redis-secret-init
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-redis-secret-init
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-redis-secret-init
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-repo-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-repo-server
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_v1_serviceaccount_argocd-server.yaml
@@ -5,10 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
   namespace: argocd

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrole_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
 rules:
 - apiGroups:

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-application-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-application-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-notifications-controller.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-notifications-controller.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: notifications-controller
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-notifications-controller
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-notifications-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-server.yaml
+++ b/manifests/production/infrastructure/gitops/rbac.authorization.k8s.io_v1_clusterrolebinding_argocd-server.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: server
     app.kubernetes.io/instance: argocd
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/version: v2.13.3
-    helm.sh/chart: argo-cd-7.7.16
   name: argocd-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:
@@ -25,13 +22,9 @@ spec:
       annotations:
         checksum/configmap-env-vars: 5063be6ef5fad5527ad98fe384832ce3752f6f1e4a682077d42f0032dc41cc47
       labels:
-        app.kubernetes.io/app-version: 26.1.0
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/instance: keycloak
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.1.0
-        helm.sh/chart: keycloak-24.4.6
     spec:
       affinity:
         nodeAffinity: null

--- a/manifests/production/platform/idp/keycloak_monitoring.coreos.com_v1_servicemonitor_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_monitoring.coreos.com_v1_servicemonitor_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_networking.k8s.io_v1_networkpolicy_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_networking.k8s.io_v1_networkpolicy_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_policy_v1_poddisruptionbudget_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_policy_v1_poddisruptionbudget_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_v1_configmap_keycloak-env-vars.yaml
+++ b/manifests/production/platform/idp/keycloak_v1_configmap_keycloak-env-vars.yaml
@@ -16,9 +16,6 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-env-vars
   namespace: keycloak

--- a/manifests/production/platform/idp/keycloak_v1_service_keycloak-headless.yaml
+++ b/manifests/production/platform/idp/keycloak_v1_service_keycloak-headless.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-headless
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_v1_service_keycloak-metrics.yaml
+++ b/manifests/production/platform/idp/keycloak_v1_service_keycloak-metrics.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak-metrics
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_v1_service_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_v1_service_keycloak.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak
 spec:

--- a/manifests/production/platform/idp/keycloak_v1_serviceaccount_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_v1_serviceaccount_keycloak.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: keycloak
     app.kubernetes.io/instance: keycloak
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.1.0
-    helm.sh/chart: keycloak-24.4.6
   name: keycloak
   namespace: keycloak

--- a/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
+++ b/manifests/production/platform/monitoring/apiregistration.k8s.io_v1_apiservice_v1beta1.metrics.k8s.io.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/manifests/production/platform/monitoring/kube-system_rbac.authorization.k8s.io_v1_rolebinding_prometheus-adapter-auth-reader.yaml
+++ b/manifests/production/platform/monitoring/kube-system_rbac.authorization.k8s.io_v1_rolebinding_prometheus-adapter-auth-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-auth-reader
   namespace: kube-system
 roleRef:

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: coredns
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-controller-manager
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-etcd
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-proxy
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     jobLabel: kube-scheduler
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_daemonset_node-exporter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring
@@ -25,11 +22,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/part-of: prometheus-node-exporter
-        app.kubernetes.io/version: 1.8.2
-        helm.sh/chart: prometheus-node-exporter-4.43.1
         jobLabel: node-exporter
         release: kube-prometheus-stack
     spec:

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:
@@ -27,8 +25,6 @@ spec:
       labels:
         app.kubernetes.io/instance: kube-prometheus-stack
         app.kubernetes.io/name: grafana
-        app.kubernetes.io/version: 11.4.0
-        helm.sh/chart: grafana-8.8.4
     spec:
       automountServiceAccountToken: true
       containers:

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring
@@ -26,11 +23,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-state-metrics
-        app.kubernetes.io/version: 2.14.0
-        helm.sh/chart: kube-state-metrics-5.28.0
         release: kube-prometheus-stack
     spec:
       automountServiceAccountToken: true

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-adapter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-adapter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring
 spec:
@@ -29,11 +26,8 @@ spec:
       labels:
         app.kubernetes.io/component: metrics
         app.kubernetes.io/instance: prometheus-adapter
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: prometheus-adapter
-        app.kubernetes.io/version: v0.12.0
-        helm.sh/chart: prometheus-adapter-4.11.0
       name: prometheus-adapter
     spec:
       affinity: {}

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
@@ -27,11 +24,8 @@ spec:
         app: kube-prometheus-stack-operator
         app.kubernetes.io/component: prometheus-operator
         app.kubernetes.io/instance: kube-prometheus-stack
-        app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
         app.kubernetes.io/part-of: kube-prometheus-stack
-        app.kubernetes.io/version: 68.3.0
-        chart: kube-prometheus-stack-68.3.0
         heritage: Helm
         release: kube-prometheus-stack
     spec:

--- a/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission-create
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-create

--- a/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission-patch
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-patch

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-config-reloaders

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-general.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-cpu-usage-seconds-total

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-cache

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-rss

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-swap

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-working-set-bytes

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-resource

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.pod-owner

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-availability.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-burnrate.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-histogram.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-slos

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-general.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-node-recording.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-state-metrics

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-apps

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-resources

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-storage

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-apiserver

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-controller-manager

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kube-proxy

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kubelet

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-scheduler

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-network

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node.rules

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus-operator

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-apiserver
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-coredns

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-etcd

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-proxy

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-kubelet
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 rules: []

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 roleRef:

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana-config-dashboards.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana-config-dashboards.yaml
@@ -19,7 +19,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-config-dashboards
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana-test.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana-test.yaml
@@ -15,7 +15,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_grafana.yaml
@@ -36,7 +36,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
@@ -31,10 +31,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
@@ -71,10 +71,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
@@ -105,10 +105,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
@@ -45,10 +45,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
@@ -53,10 +53,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
@@ -25,10 +25,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_datasource: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
@@ -28,10 +28,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
@@ -77,10 +77,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
@@ -161,10 +161,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
@@ -60,10 +60,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
@@ -163,10 +163,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
@@ -57,10 +57,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
@@ -150,10 +150,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
@@ -164,10 +164,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
@@ -171,10 +171,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
@@ -102,10 +102,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
@@ -78,10 +78,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
@@ -110,10 +110,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
@@ -595,10 +595,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
@@ -34,10 +34,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
@@ -55,10 +55,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
@@ -63,10 +63,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
@@ -59,10 +59,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
@@ -42,10 +42,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
@@ -35,10 +35,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
@@ -44,10 +44,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
@@ -47,10 +47,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
@@ -56,10 +56,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
@@ -62,10 +62,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-grafana
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     grafana_dashboard: "1"
     heritage: Helm
     release: kube-prometheus-stack

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_prometheus-adapter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_prometheus-adapter.yaml
@@ -46,10 +46,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_pod_grafana-test.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_pod_grafana-test.yaml
@@ -7,8 +7,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring
 spec:

--- a/manifests/production/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: alertmanager-k8s

--- a/manifests/production/platform/monitoring/monitoring_v1_secret_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_secret_grafana.yaml
@@ -8,8 +8,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 type: Opaque

--- a/manifests/production/platform/monitoring/monitoring_v1_service_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_grafana.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/production/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"

--- a/manifests/production/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"

--- a/manifests/production/platform/monitoring/monitoring_v1_service_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_kube-state-metrics.yaml
@@ -6,11 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_service_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_node-exporter.yaml
@@ -6,11 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     jobLabel: node-exporter
     release: kube-prometheus-stack
   name: node-exporter

--- a/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-adapter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-adapter.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_grafana-test.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_grafana-test.yaml
@@ -7,7 +7,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-test
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_grafana.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_grafana.yaml
@@ -5,7 +5,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
@@ -9,11 +9,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-alertmanager
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_kube-state-metrics.yaml
@@ -5,11 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_node-exporter.yaml
@@ -5,11 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/version: 1.8.2
-    helm.sh/chart: prometheus-node-exporter-4.43.1
     release: kube-prometheus-stack
   name: node-exporter
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-adapter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-adapter.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
@@ -6,11 +6,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_grafana-clusterrole.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_grafana-clusterrole.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-clusterrole
 rules:
 - apiGroups:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
 rules:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-metrics.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-metrics
 rules:
 - apiGroups:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-resource-reader.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-adapter-resource-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-resource-reader
 rules:
 - apiGroups:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_grafana-clusterrolebinding.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_grafana-clusterrolebinding.yaml
@@ -4,8 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: grafana
-    app.kubernetes.io/version: 11.4.0
-    helm.sh/chart: grafana-8.8.4
   name: grafana-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
@@ -8,11 +8,8 @@ metadata:
     app: kube-prometheus-stack-admission
     app.kubernetes.io/component: prometheus-operator-webhook
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_kube-state-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
-    app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
     release: kube-prometheus-stack
   name: kube-state-metrics
 roleRef:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-hpa-controller-metrics.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-hpa-controller-metrics.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-hpa-controller-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-resource-reader.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-resource-reader.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-resource-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-system-auth-delegator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-adapter-system-auth-delegator.yaml
@@ -4,11 +4,8 @@ metadata:
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
-    app.kubernetes.io/version: v0.12.0
-    helm.sh/chart: prometheus-adapter-4.11.0
   name: prometheus-adapter-system-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
@@ -5,11 +5,8 @@ metadata:
     app: kube-prometheus-stack-operator
     app.kubernetes.io/component: prometheus-operator
     app.kubernetes.io/instance: kube-prometheus-stack
-    app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    app.kubernetes.io/version: 68.3.0
-    chart: kube-prometheus-stack-68.3.0
     heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator

--- a/platform/idp/base/kustomization.yaml
+++ b/platform/idp/base/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
 - home/groups.yaml
 - home/roles.yaml
 
+components:
+- ../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: keycloak
   repo: oci://registry-1.docker.io/bitnamicharts

--- a/platform/monitoring/base/kustomization.yaml
+++ b/platform/monitoring/base/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - keycloak
 - gateway
 
+components:
+- ../../../shared/components/strip-helm-labels
+
 helmCharts:
 - name: kube-prometheus-stack
   repo: https://prometheus-community.github.io/helm-charts

--- a/shared/components/strip-helm-labels/kustomization.yaml
+++ b/shared/components/strip-helm-labels/kustomization.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+- target:
+    labelSelector: helm.sh/chart
+  patch: |
+    - op: remove
+      path: /metadata/labels/helm.sh~1chart
+- target:
+    labelSelector: chart
+  patch: |
+    - op: remove
+      path: /metadata/labels/chart
+- target:
+    labelSelector: app.kubernetes.io/version
+  patch: |
+    - op: remove
+      path: /metadata/labels/app.kubernetes.io~1version
+- target:
+    labelSelector: app.kubernetes.io/app-version
+  patch: |
+    - op: remove
+      path: /metadata/labels/app.kubernetes.io~1app-version
+- target:
+    labelSelector: app.kubernetes.io/managed-by=Helm
+  patch: |
+    - op: remove
+      path: /metadata/labels/app.kubernetes.io~1managed-by
+- target:
+    kind: (Deployment|StatefulSet|DaemonSet)
+  path: patch.yaml

--- a/shared/components/strip-helm-labels/patch.yaml
+++ b/shared/components/strip-helm-labels/patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: patch
+spec:
+  template:
+    metadata:
+      labels:
+        chart: null
+        helm.sh/chart: null
+        app.kubernetes.io/version: null
+        app.kubernetes.io/app-version: null
+        app.kubernetes.io/managed-by: null


### PR DESCRIPTION
This strips labels added by Helm and/or other version labels. The version labels are informational, but clutter diffs when bumping a helm chart's version, for example.

This is implemented as a Kustomize component that kustomizations referencing a Helm chart pull in to patch the generated resources.