### PR TITLE
fix(kustomize): Strip heritage Helm label

### DIFF
--- a/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 webhooks:

--- a/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 webhooks:

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: coredns
     release: kube-prometheus-stack
   name: k8s-coredns

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-controller-manager
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-etcd
     release: kube-prometheus-stack
   name: k8s-kube-etcd

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-proxy
     release: kube-prometheus-stack
   name: k8s-kube-proxy

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-scheduler
     release: kube-prometheus-stack
   name: k8s-kube-scheduler

--- a/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring
@@ -26,7 +25,6 @@ spec:
         app.kubernetes.io/instance: kube-prometheus-stack
         app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
         app.kubernetes.io/part-of: kube-prometheus-stack
-        heritage: Helm
         release: kube-prometheus-stack
     spec:
       automountServiceAccountToken: true

--- a/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-create
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-patch
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-config-reloaders
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-general.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-cpu-usage-seconds-total
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-cache
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-rss
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-swap
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-working-set-bytes
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-resource
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.pod-owner
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-availability.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-burnrate.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-histogram.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-slos
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-general.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-node-recording.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-state-metrics
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-apps
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-resources
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-storage
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-apiserver
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-controller-manager
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kube-proxy
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kubelet
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-scheduler
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-network
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node.rules
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus-operator
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-apiserver
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-coredns
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-etcd
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-proxy
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kubelet
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
@@ -33,7 +33,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager-overview
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
@@ -73,7 +73,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
@@ -107,7 +107,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-cluster-total
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
@@ -47,7 +47,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-controller-manager
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
@@ -55,7 +55,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
@@ -27,7 +27,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_datasource: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-grafana-datasource
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
@@ -30,7 +30,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-grafana-overview
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
@@ -79,7 +79,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-coredns
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
@@ -163,7 +163,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-cluster
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
@@ -62,7 +62,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-multicluster
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
@@ -165,7 +165,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-namespace
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
@@ -59,7 +59,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-node
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
@@ -152,7 +152,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-pod
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
@@ -166,7 +166,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-workload
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
@@ -173,7 +173,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-workloads-namespace
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
@@ -104,7 +104,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
@@ -80,7 +80,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-namespace-by-pod
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
@@ -112,7 +112,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-namespace-by-workload
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
@@ -597,7 +597,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-cluster-rsrc-use
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
@@ -36,7 +36,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-rsrc-use
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
@@ -57,7 +57,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes-aix
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
@@ -65,7 +65,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes-darwin
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
@@ -61,7 +61,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
@@ -44,7 +44,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-persistentvolumesusage
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
@@ -37,7 +37,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-pod-total
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
@@ -46,7 +46,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
@@ -49,7 +49,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-proxy
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
@@ -58,7 +58,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-scheduler
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
@@ -64,7 +64,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-workload-total
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
@@ -7,7 +7,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: alertmanager-k8s
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"
   name: k8s-alertmanager

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"
   name: k8s-prometheus

--- a/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-alertmanager
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 rules:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
 rules:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
 rules:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 roleRef:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
 roleRef:

--- a/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
+++ b/manifests/dev/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
 roleRef:

--- a/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_k8s-admission.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 webhooks:

--- a/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_k8s-admission.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 webhooks:

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-coredns.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: coredns
     release: kube-prometheus-stack
   name: k8s-coredns

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-controller-manager
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-etcd
     release: kube-prometheus-stack
   name: k8s-kube-etcd

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-proxy
     release: kube-prometheus-stack
   name: k8s-kube-proxy

--- a/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_k8s-kube-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     jobLabel: kube-scheduler
     release: kube-prometheus-stack
   name: k8s-kube-scheduler

--- a/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring
@@ -26,7 +25,6 @@ spec:
         app.kubernetes.io/instance: kube-prometheus-stack
         app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
         app.kubernetes.io/part-of: kube-prometheus-stack
-        heritage: Helm
         release: kube-prometheus-stack
     spec:
       automountServiceAccountToken: true

--- a/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-create
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/production/platform/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission-patch
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_alertmanager_k8s.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheus_k8s.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-alertmanager.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-config-reloaders.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-config-reloaders
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-general.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-general.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-cpu-usage-seconds-total.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-cpu-usage-seconds-total
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-cache.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-cache
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-rss.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-rss
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-swap.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-swap
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-memory-working-set-bytes.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-memory-working-set-bytes
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.container-resource.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.container-resource
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-k8s.rules.pod-owner.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s.rules.pod-owner
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-availability.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-availability.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-burnrate.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-burnrate.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-histogram.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-histogram.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-apiserver-slos.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-apiserver-slos
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-general.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-general.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-prometheus-node-recording.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-prometheus-node-recording.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-scheduler.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kube-state-metrics.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-state-metrics
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubelet.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-apps.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-apps
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-resources.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-resources
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-storage.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-storage
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-apiserver.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-apiserver
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-controller-manager
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kube-proxy
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-kubelet.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-kubelet
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system-scheduler
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-kubernetes-system.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubernetes-system
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-exporter.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-exporter
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node-network.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-network
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-node.rules.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node.rules
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus-operator.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus-operator
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_prometheusrule_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-alertmanager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-apiserver.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-apiserver
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-coredns.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-coredns
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-coredns
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-controller-manager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-controller-manager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-controller-manager
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-etcd.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-etcd
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-etcd
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-proxy.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-proxy
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-proxy
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kube-scheduler.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kube-scheduler
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kube-scheduler
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-kubelet.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-kubelet
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_monitoring.coreos.com_v1_servicemonitor_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_role_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_rbac.authorization.k8s.io_v1_rolebinding_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-alertmanager-overview.yaml
@@ -33,7 +33,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager-overview
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-apiserver.yaml
@@ -73,7 +73,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-apiserver
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-cluster-total.yaml
@@ -107,7 +107,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-cluster-total
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-controller-manager.yaml
@@ -47,7 +47,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-controller-manager
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-etcd.yaml
@@ -55,7 +55,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-etcd
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-datasource.yaml
@@ -27,7 +27,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_datasource: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-grafana-datasource
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-grafana-overview.yaml
@@ -30,7 +30,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-grafana-overview
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-coredns.yaml
@@ -79,7 +79,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-coredns
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-cluster.yaml
@@ -163,7 +163,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-cluster
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-multicluster.yaml
@@ -62,7 +62,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-multicluster
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-namespace.yaml
@@ -165,7 +165,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-namespace
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-node.yaml
@@ -59,7 +59,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-node
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-pod.yaml
@@ -152,7 +152,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-pod
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workload.yaml
@@ -166,7 +166,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-workload
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-k8s-resources-workloads-namespace.yaml
@@ -173,7 +173,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-k8s-resources-workloads-namespace
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-kubelet.yaml
@@ -104,7 +104,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-kubelet
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-pod.yaml
@@ -80,7 +80,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-namespace-by-pod
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-namespace-by-workload.yaml
@@ -112,7 +112,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-namespace-by-workload
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-cluster-rsrc-use.yaml
@@ -597,7 +597,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-cluster-rsrc-use
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-node-rsrc-use.yaml
@@ -36,7 +36,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-node-rsrc-use
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-aix.yaml
@@ -57,7 +57,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes-aix
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes-darwin.yaml
@@ -65,7 +65,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes-darwin
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-nodes.yaml
@@ -61,7 +61,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-nodes
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-persistentvolumesusage.yaml
@@ -44,7 +44,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-persistentvolumesusage
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-pod-total.yaml
@@ -37,7 +37,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-pod-total
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-prometheus.yaml
@@ -46,7 +46,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-proxy.yaml
@@ -49,7 +49,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-proxy
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-scheduler.yaml
@@ -58,7 +58,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-scheduler
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_configmap_k8s-workload-total.yaml
@@ -64,7 +64,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
     grafana_dashboard: "1"
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-workload-total
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_secret_alertmanager-k8s.yaml
@@ -7,7 +7,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: alertmanager-k8s
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_k8s-alertmanager.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-alertmanager
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"
   name: k8s-alertmanager

--- a/manifests/production/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
     self-monitor: "true"
   name: k8s-prometheus

--- a/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_service_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-admission.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-alertmanager.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-alertmanager
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-alertmanager
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_k8s-prometheus.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
   namespace: monitoring

--- a/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/monitoring_v1_serviceaccount_prometheus-operator.yaml
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
   namespace: monitoring

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 rules:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
 rules:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrole_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
 rules:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-admission.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-admission
 roleRef:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_k8s-prometheus.yaml
@@ -5,7 +5,6 @@ metadata:
     app: kube-prometheus-stack-prometheus
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: k8s-prometheus
 roleRef:

--- a/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
+++ b/manifests/production/platform/monitoring/rbac.authorization.k8s.io_v1_clusterrolebinding_prometheus-operator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/instance: kube-prometheus-stack
     app.kubernetes.io/name: kube-prometheus-stack-prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus-stack
-    heritage: Helm
     release: kube-prometheus-stack
   name: prometheus-operator
 roleRef:

--- a/shared/components/strip-helm-labels/kustomization.yaml
+++ b/shared/components/strip-helm-labels/kustomization.yaml
@@ -29,5 +29,10 @@ patches:
     - op: remove
       path: /metadata/labels/app.kubernetes.io~1managed-by
 - target:
+    labelSelector: heritage=Helm
+  patch: |
+    - op: remove
+      path: /metadata/labels/heritage
+- target:
     kind: (Deployment|StatefulSet|DaemonSet)
   path: patch.yaml

--- a/shared/components/strip-helm-labels/patch.yaml
+++ b/shared/components/strip-helm-labels/patch.yaml
@@ -11,3 +11,4 @@ spec:
         app.kubernetes.io/version: null
         app.kubernetes.io/app-version: null
         app.kubernetes.io/managed-by: null
+        heritage: null


### PR DESCRIPTION
This additionally strips the `heritage` label from resources generated by Helm.