### PR TITLE
fix(argocd): Adds probes for dex to handle upstream IdP downtime

### DIFF
--- a/infrastructure/gitops/base/kustomization.yaml
+++ b/infrastructure/gitops/base/kustomization.yaml
@@ -25,6 +25,11 @@ helmCharts:
   apiVersions:
   - monitoring.coreos.com/v1
   valuesInline:
+    dex:
+      readinessProbe:
+        enabled: true
+      livenessProbe:
+        enabled: true
     configs:
       params:
         server.insecure: true

--- a/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/dev/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -64,6 +64,16 @@ spec:
               optional: true
         image: ghcr.io/dexidp/dex:v2.41.1
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/live
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: dex-server
         ports:
         - containerPort: 5556
@@ -75,6 +85,16 @@ spec:
         - containerPort: 5558
           name: metrics
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/ready
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/gitops/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -64,6 +64,16 @@ spec:
               optional: true
         image: ghcr.io/dexidp/dex:v2.41.1
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/live
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: dex-server
         ports:
         - containerPort: 5556
@@ -75,6 +85,16 @@ spec:
         - containerPort: 5558
           name: metrics
           protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz/ready
+            port: metrics
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes #376 by enabling probes built into the upstream Helm chart.