### PR TITLE
fix(monitoring): Move node-exporter to kube-system to enable pod security

### DIFF
--- a/manifests/dev/platform/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   revisionHistoryLimit: 10
   selector:

--- a/manifests/dev/platform/monitoring/kube-system_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   attachMetadata:
     node: true

--- a/manifests/dev/platform/monitoring/kube-system_v1_service_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_service_node-exporter.yaml
@@ -11,7 +11,7 @@ metadata:
     jobLabel: node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   ports:
   - name: http-metrics

--- a/manifests/dev/platform/monitoring/kube-system_v1_serviceaccount_node-exporter.yaml
+++ b/manifests/dev/platform/monitoring/kube-system_v1_serviceaccount_node-exporter.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system

--- a/manifests/dev/platform/monitoring/v1_namespace_monitoring.yaml
+++ b/manifests/dev/platform/monitoring/v1_namespace_monitoring.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
   name: monitoring

--- a/manifests/production/platform/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   revisionHistoryLimit: 10
   selector:

--- a/manifests/production/platform/monitoring/kube-system_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/kube-system_monitoring.coreos.com_v1_servicemonitor_node-exporter.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   attachMetadata:
     node: true

--- a/manifests/production/platform/monitoring/kube-system_v1_service_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_service_node-exporter.yaml
@@ -11,7 +11,7 @@ metadata:
     jobLabel: node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system
 spec:
   ports:
   - name: http-metrics

--- a/manifests/production/platform/monitoring/kube-system_v1_serviceaccount_node-exporter.yaml
+++ b/manifests/production/platform/monitoring/kube-system_v1_serviceaccount_node-exporter.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/part-of: prometheus-node-exporter
     release: kube-prometheus-stack
   name: node-exporter
-  namespace: monitoring
+  namespace: kube-system

--- a/manifests/production/platform/monitoring/v1_namespace_monitoring.yaml
+++ b/manifests/production/platform/monitoring/v1_namespace_monitoring.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
   name: monitoring

--- a/platform/monitoring/base/kustomization.yaml
+++ b/platform/monitoring/base/kustomization.yaml
@@ -47,6 +47,7 @@ helmCharts:
       fullnameOverride: prometheus-operator
     cleanPrometheusOperatorObjectNames: true
     prometheus-node-exporter:
+      namespaceOverride: kube-system
       fullnameOverride: node-exporter
       prometheus:
         monitor:

--- a/platform/monitoring/base/namespace.yaml
+++ b/platform/monitoring/base/namespace.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
-  labels:
-    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Moves node-exporter `DaemonSet` to `kube-system` namespace to allow setting `restricted` Pod Security Standard on `monitoring` namespace.