### PR TITLE
fix(cilium): Use single replica in dev cluster

### DIFF
--- a/infrastructure/controllers/cilium/dev/kustomization.yaml
+++ b/infrastructure/controllers/cilium/dev/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 
 resources:
 - ../base
+
+patches:
+- path: patches/cilium-operator.yaml

--- a/infrastructure/controllers/cilium/dev/patches/cilium-operator.yaml
+++ b/infrastructure/controllers/cilium/dev/patches/cilium-operator.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cilium-operator
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    $patch: replace
+    type: Recreate

--- a/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/dev/infrastructure/controllers/cilium/apps_v1_deployment_cilium-operator.yaml
@@ -9,16 +9,13 @@ metadata:
   name: cilium-operator
   namespace: kube-system
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       io.cilium/app: operator
       name: cilium-operator
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 50%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Patches the cilium-operator `Deployment` in the dev cluster to use a single replica and a `Recreate` strategy.