### PR TITLE
ci(renovate): Update regex matchers

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -85,3 +85,11 @@ tasks:
     - manifests/**/*
     cmds:
     - kubeconform -output pretty -kubernetes-version {{ .KUBERNETES_VERSION | trimPrefix "v" }} -schema-location default -schema-location 'schemas/{{`{{.Group}}`}}/{{`{{.ResourceKind}}`}}_{{`{{.ResourceAPIVersion}}`}}.json' -skip CustomResourceDefinition,EnvoyProxy manifests/
+
+  renovate:
+    env:
+      LOG_LEVEL: DEBUG
+      GITHUB_COM_TOKEN:
+        sh: gh auth token
+    cmds:
+    - renovate --platform=local

--- a/apps/actual/base/actual-server/configmap.yaml
+++ b/apps/actual/base/actual-server/configmap.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/configmap.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/actual/base/actual-server/deployment.yaml
+++ b/apps/actual/base/actual-server/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/actual/base/actual-server/pvc.yaml
+++ b/apps/actual/base/actual-server/pvc.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/apps/actual/base/actual-server/service.yaml
+++ b/apps/actual/base/actual-server/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/actual/base/namespace.yaml
+++ b/apps/actual/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/apps/actual/dev/patches/pvcs.yaml
+++ b/apps/actual/dev/patches/pvcs.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/apps/ezxss/base/configmap.yaml
+++ b/apps/ezxss/base/configmap.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/configmap.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/ezxss/base/deployment.yaml
+++ b/apps/ezxss/base/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/ezxss/base/namespace.yaml
+++ b/apps/ezxss/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/apps/ezxss/base/service.yaml
+++ b/apps/ezxss/base/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/paperless-ngx/base/gotenberg/deployment.yaml
+++ b/apps/paperless-ngx/base/gotenberg/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/paperless-ngx/base/gotenberg/service.yaml
+++ b/apps/paperless-ngx/base/gotenberg/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/paperless-ngx/base/namespace.yaml
+++ b/apps/paperless-ngx/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/apps/paperless-ngx/base/paperless-ngx/deployment.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/paperless-ngx/base/paperless-ngx/pvcs.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/pvcs.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,7 +11,7 @@ spec:
     requests:
       storage: 200Gi
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/apps/paperless-ngx/base/paperless-ngx/service.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/paperless-ngx/base/redis/deployment.yaml
+++ b/apps/paperless-ngx/base/redis/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/paperless-ngx/base/redis/service.yaml
+++ b/apps/paperless-ngx/base/redis/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/paperless-ngx/base/tika/deployment.yaml
+++ b/apps/paperless-ngx/base/tika/deployment.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/deployment.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/deployment.json
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/paperless-ngx/base/tika/service.yaml
+++ b/apps/paperless-ngx/base/tika/service.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/service.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/service.json
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/paperless-ngx/dev/patches/pvcs.yaml
+++ b/apps/paperless-ngx/dev/patches/pvcs.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/persistentvolumeclaim.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/persistentvolumeclaim.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/clusters/production/talconfig.yaml
+++ b/clusters/production/talconfig.yaml
@@ -1,4 +1,3 @@
-# renovate: datasource=github-releases depName=budimanjojo/talhelper
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/v3.0.16/pkg/config/schemas/talconfig.json
 clusterName: production
 # renovate: datasource=github-releases depName=siderolabs/talos

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
                   kustomize
                   kyverno-chainsaw
                   pre-commit
+                  renovate
                   sops
                   ssh-to-age
                   talhelper

--- a/infrastructure/configs/base/kubevirt/kustomization.yaml
+++ b/infrastructure/configs/base/kubevirt/kustomization.yaml
@@ -3,7 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# renovate: datasource=github-releases depName=kubevirt/kubevirt
 - https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/kubevirt-cr.yaml
-# renovate: datasource=github-releases depName=kubevirt/containerized-data-importer
 - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.61.0/cdi-cr.yaml

--- a/infrastructure/configs/dev/linstor/storageclasses.yaml
+++ b/infrastructure/configs/dev/linstor/storageclasses.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/storageclass.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/storageclass.json
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/infrastructure/configs/production/linstor/storageclasses.yaml
+++ b/infrastructure/configs/production/linstor/storageclasses.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/storageclass.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/storageclass.json
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -18,7 +18,7 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/storageclass.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/storageclass.json
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -38,7 +38,7 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/storageclass.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/storageclass.json
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -58,7 +58,7 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/storageclass.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/storageclass.json
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/infrastructure/controllers/cert-manager/base/namespace.yaml
+++ b/infrastructure/controllers/cert-manager/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/cnpg/base/namespace.yaml
+++ b/infrastructure/controllers/cnpg/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/crossplane/base/namespace.yaml
+++ b/infrastructure/controllers/crossplane/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/envoy-gateway/base/namespace.yaml
+++ b/infrastructure/controllers/envoy-gateway/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/external-secrets/base/namespace.yaml
+++ b/infrastructure/controllers/external-secrets/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/kubevirt/base/kustomization.yaml
+++ b/infrastructure/controllers/kubevirt/base/kustomization.yaml
@@ -3,9 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-# renovate: datasource=github-releases depName=kubevirt/kubevirt
 - https://github.com/kubevirt/kubevirt/releases/download/v1.4.0/kubevirt-operator.yaml
-# renovate: datasource=github-releases depName=kubevirt/containerized-data-importer
 - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.61.0/cdi-operator.yaml
 
 patches:

--- a/infrastructure/controllers/kyverno/base/clusterrolebindings.yaml
+++ b/infrastructure/controllers/kyverno/base/clusterrolebindings.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/clusterrolebinding.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/clusterrolebinding.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,7 +16,7 @@ subjects:
   name: kyverno-admission-controller
   namespace: kyverno
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/clusterrolebinding.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/clusterrolebinding.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/infrastructure/controllers/kyverno/base/clusterroles.yaml
+++ b/infrastructure/controllers/kyverno/base/clusterroles.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/clusterrole.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/clusterrole.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,7 +19,7 @@ rules:
   - update
   - delete
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/clusterrole.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/clusterrole.json
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/infrastructure/controllers/kyverno/base/namespace.yaml
+++ b/infrastructure/controllers/kyverno/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/mariadb-operator/base/namespace.yaml
+++ b/infrastructure/controllers/mariadb-operator/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/velero/base/namespace.yaml
+++ b/infrastructure/controllers/velero/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/infrastructure/controllers/velero/dev/secrets.yaml
+++ b/infrastructure/controllers/velero/dev/secrets.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/secret.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/secret.json
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,7 +11,7 @@ stringData:
     aws_access_key_id = TESTTEST
     aws_secret_access_key = TESTTEST
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/secret.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/secret.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/infrastructure/gitops/base/namespace.yaml
+++ b/infrastructure/gitops/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform/idp/base/namespace.yaml
+++ b/platform/idp/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/platform/idp/dev/secrets/crossplane-credentials.yaml
+++ b/platform/idp/dev/secrets/crossplane-credentials.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/secret.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/secret.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/platform/idp/dev/secrets/keycloak-admin.yaml
+++ b/platform/idp/dev/secrets/keycloak-admin.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/secret.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/secret.json
 apiVersion: v1
 kind: Secret
 metadata:

--- a/platform/monitoring/base/namespace.yaml
+++ b/platform/monitoring/base/namespace.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.31.3/namespace.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.31.3/namespace.json
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    ":maintainLockFilesWeekly"
-  ],
-  "ignorePaths": [
-    "manifests/**"
-  ],
+  "extends": ["config:best-practices", ":maintainLockFilesWeekly"],
+  "ignorePaths": ["manifests/**"],
   "nix": {
     "enabled": true
   },
@@ -22,9 +17,32 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "\\.(yaml|sh)$"
+      "fileMatch": [".*"],
+      "matchStrings": [
+        "https:\/\/github\\.com\/(?<depName>.*\/.*?)\/releases\/download\/(?<currentValue>.*?)\/"
       ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [".*"],
+      "matchStrings": [
+        "https:\/\/raw\\.githubusercontent\\.com\/(?<depName>[^\/]*\/[^\/]*)\/(?<currentValue>.*?)\/"
+      ],
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [".*"],
+      "matchStrings": [
+        "https:\/\/raw\\.githubusercontent\\.com\/yannh\/kubernetes-json-schema\/master\/(?<currentValue>.*?)\/"
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [".*"],
       "matchStringsStrategy": "recursive",
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)(?: registryUrl=(?<registryUrl>.*?))?\\n[^\\n]+",


### PR DESCRIPTION
Update matchers for renovate to more easily pickup GitHub releases and tags based on the URL. Also adds a special matcher for the `yannh/kubernetes-json-schema` project that updates the path within to the current version of Kubernetes.