### PR TITLE
fix(mariadb): Capture MariaDB database image in renovate process

### DIFF
--- a/apps/ezxss/base/database.yaml
+++ b/apps/ezxss/base/database.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   username: ezxss
   database: ezxss
-  image: mariadb:11.3.2
+  image: ghcr.io/mariadb/mariadb
   storage:
     size: 1Gi
     storageClassName: ssd-r1

--- a/apps/ezxss/base/kustomization.yaml
+++ b/apps/ezxss/base/kustomization.yaml
@@ -14,3 +14,8 @@ resources:
 images:
 - name: ghcr.io/gadgetmg/ezxss
   newTag: master@sha256:403d7bd266634a1a7390ab627568a833e12c625ff370134c4bfbf69e93baea90
+- name: ghcr.io/mariadb/mariadb
+  newTag: 11.6.2-ubi9@sha256:c25e174044a03b029514f2c4733f1d1b5e5a7e165bcd802e986ccd1a7e6e81fc
+
+components:
+- ../../../shared/components/crd-configurations

--- a/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: ezxss
 spec:
   database: ezxss
-  image: mariadb:11.3.2
+  image: ghcr.io/mariadb/mariadb:11.6.2-ubi9@sha256:c25e174044a03b029514f2c4733f1d1b5e5a7e165bcd802e986ccd1a7e6e81fc
   metrics:
     enabled: true
     exporter:

--- a/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: ezxss
 spec:
   database: ezxss
-  image: mariadb:11.3.2
+  image: ghcr.io/mariadb/mariadb:11.6.2-ubi9@sha256:c25e174044a03b029514f2c4733f1d1b5e5a7e165bcd802e986ccd1a7e6e81fc
   metrics:
     enabled: true
     exporter:

--- a/shared/components/crd-configurations/configuration.yaml
+++ b/shared/components/crd-configurations/configuration.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/image
+  kind: MariaDB

--- a/shared/components/crd-configurations/kustomization.yaml
+++ b/shared/components/crd-configurations/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+configurations:
+- configuration.yaml


### PR DESCRIPTION
Previously, renovate was not able to capture the image specified in the MariaDB custom resource to keep it up to date. This teaches Kustomize about the image path so it can be managed automatically like any other image specified in the `kustomization.yaml` file.