### PR TITLE
ci(renovate): Enable automerge and give workflow jobs unique names

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  main:
+  pre-commit:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  main:
+  tests:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout

--- a/platform/idp/base/kustomization.yaml
+++ b/platform/idp/base/kustomization.yaml
@@ -19,7 +19,7 @@ components:
 
 helmCharts:
 - name: keycloak
-  repo: oci://registry-1.docker.io/bitnamicharts
+  repo: oci://docker.io/bitnamicharts
   version: 24.4.6
   releaseName: keycloak
   namespace: keycloak

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":maintainLockFilesWeekly"],
+  "extends": ["config:best-practices", ":maintainLockFilesWeekly", ":automergeAll"],
   "ignorePaths": ["manifests/**"],
   "nix": {
     "enabled": true
@@ -9,7 +9,7 @@
     {
       "matchPackageNames": [
         "docker.io/envoyproxy/gateway-helm",
-        "registry-1.docker.io/bitnamicharts/keycloak"
+        "docker.io/bitnamicharts/keycloak"
       ],
       "pinDigests": false
     }


### PR DESCRIPTION
Enables Renovate's automerge capability and renames workflow jobs to be unique so they can be specified as requirements in branch protection rules.