### PR TITLE
feat(coredns-external): Add external-facing CoreDNS instance

### DIFF
--- a/infrastructure/controllers/coredns-external/base/kustomization.yaml
+++ b/infrastructure/controllers/coredns-external/base/kustomization.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+
+components:
+- ../../../../shared/components/strip-helm-labels
+
+helmCharts:
+- name: coredns
+  repo: https://coredns.github.io/helm
+  releaseName: coredns
+  namespace: coredns-external
+  version: v1.39.0
+  valuesInline:
+    serviceType: LoadBalancer
+    prometheus:
+      service:
+        enabled: true
+      monitor:
+        enabled: true
+    isClusterService: false
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    servers:
+    - zones:
+      - zone: svc.seigra.net
+      port: 53
+      plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 5s
+      - name: ready
+      - name: k8s_external
+      - name: kubernetes
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: loop
+      - name: reload
+      - name: loadbalance

--- a/infrastructure/controllers/coredns-external/base/namespace.yaml
+++ b/infrastructure/controllers/coredns-external/base/namespace.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.32.1/namespace.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coredns-external

--- a/infrastructure/controllers/coredns-external/kind/kustomization.yaml
+++ b/infrastructure/controllers/coredns-external/kind/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/infrastructure/controllers/coredns-external/production/kustomization.yaml
+++ b/infrastructure/controllers/coredns-external/production/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base

--- a/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_apps_v1_deployment_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_apps_v1_deployment_coredns.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: coredns
+      app.kubernetes.io/name: coredns
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: fed8446c9a58751c35805aa698906b3afeda3658cd845df27dffc1042d41677a
+      labels:
+        app.kubernetes.io/instance: coredns
+        app.kubernetes.io/name: coredns
+    spec:
+      containers:
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: coredns/coredns:1.12.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: udp-53
+          protocol: UDP
+        - containerPort: 53
+          name: tcp-53
+          protocol: TCP
+        - containerPort: 9153
+          name: tcp-9153
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          items:
+          - key: Corefile
+            path: Corefile
+          name: coredns
+        name: config-volume

--- a/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_configmap_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_configmap_coredns.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  Corefile: |-
+    svc.seigra.net:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        k8s_external
+        kubernetes
+        prometheus 0.0.0.0:9153
+        loop
+        reload
+        loadbalance
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external

--- a/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns-metrics.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns-metrics.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns-metrics
+  namespace: coredns-external
+spec:
+  ports:
+  - name: metrics
+    port: 9153
+    targetPort: 9153
+  selector:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns

--- a/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external
+spec:
+  ports:
+  - name: udp-53
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: tcp-53
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  type: LoadBalancer

--- a/manifests/kind/infrastructure/controllers/coredns-external/default_monitoring.coreos.com_v1_servicemonitor_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/default_monitoring.coreos.com_v1_servicemonitor_coredns.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - coredns-external
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics
+      app.kubernetes.io/instance: coredns
+      app.kubernetes.io/name: coredns

--- a/manifests/kind/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrole_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrole_coredns.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch

--- a/manifests/kind/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrolebinding_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrolebinding_coredns.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: coredns-external

--- a/manifests/kind/infrastructure/controllers/coredns-external/v1_namespace_coredns-external.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/v1_namespace_coredns-external.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coredns-external

--- a/manifests/production/infrastructure/controllers/coredns-external/coredns-external_apps_v1_deployment_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/coredns-external_apps_v1_deployment_coredns.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: coredns
+      app.kubernetes.io/name: coredns
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: fed8446c9a58751c35805aa698906b3afeda3658cd845df27dffc1042d41677a
+      labels:
+        app.kubernetes.io/instance: coredns
+        app.kubernetes.io/name: coredns
+    spec:
+      containers:
+      - args:
+        - -conf
+        - /etc/coredns/Corefile
+        image: coredns/coredns:1.12.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: coredns
+        ports:
+        - containerPort: 53
+          name: udp-53
+          protocol: UDP
+        - containerPort: 53
+          name: tcp-53
+          protocol: TCP
+        - containerPort: 9153
+          name: tcp-9153
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/coredns
+          name: config-volume
+      securityContext:
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          items:
+          - key: Corefile
+            path: Corefile
+          name: coredns
+        name: config-volume

--- a/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_configmap_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_configmap_coredns.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  Corefile: |-
+    svc.seigra.net:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        k8s_external
+        kubernetes
+        prometheus 0.0.0.0:9153
+        loop
+        reload
+        loadbalance
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external

--- a/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns-metrics.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns-metrics.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns-metrics
+  namespace: coredns-external
+spec:
+  ports:
+  - name: metrics
+    port: 9153
+    targetPort: 9153
+  selector:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns

--- a/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/coredns-external_v1_service_coredns.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+  namespace: coredns-external
+spec:
+  ports:
+  - name: udp-53
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: tcp-53
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  type: LoadBalancer

--- a/manifests/production/infrastructure/controllers/coredns-external/default_monitoring.coreos.com_v1_servicemonitor_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/default_monitoring.coreos.com_v1_servicemonitor_coredns.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+spec:
+  endpoints:
+  - port: metrics
+  namespaceSelector:
+    matchNames:
+    - coredns-external
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics
+      app.kubernetes.io/instance: coredns
+      app.kubernetes.io/name: coredns

--- a/manifests/production/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrole_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrole_coredns.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch

--- a/manifests/production/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrolebinding_coredns.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/rbac.authorization.k8s.io_v1_clusterrolebinding_coredns.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: coredns
+    app.kubernetes.io/name: coredns
+  name: coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: coredns-external

--- a/manifests/production/infrastructure/controllers/coredns-external/v1_namespace_coredns-external.yaml
+++ b/manifests/production/infrastructure/controllers/coredns-external/v1_namespace_coredns-external.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coredns-external


### PR DESCRIPTION
Adds an external-facing CoreDNS instance to resolve DNS names to hosted services with an `ExternalIP` by way of the [`k8s_external`](https://coredns.io/plugins/k8s_external/) plugin.

Names of services will resolve like: `<service-name>.<namespace>.svc.seigra.net`