### PR TITLE
fix(argocd): Fix looping caused by updates to status fields

### DIFF
--- a/infrastructure/controllers/argocd/base/kustomization.yaml
+++ b/infrastructure/controllers/argocd/base/kustomization.yaml
@@ -36,6 +36,9 @@ helmCharts:
         controller.diff.server.side: true
         applicationsetcontroller.enable.progressive.syncs: true
       cm:
+        resource.customizations.ignoreResourceUpdates.all: |
+          jsonPointers:
+          - /status
         resource.customizations: |
           argoproj.io/Application:
             health.lua: |

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: dex-server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: repo-server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: application-controller

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
@@ -148,6 +148,9 @@ data:
         hs.status = "Progressing"
         hs.message = "Waiting for resource to be created"
         return hs
+  resource.customizations.ignoreResourceUpdates.all: |
+    jsonPointers:
+    - /status
   resource.exclusions: |
     - apiGroups:
         - cilium.io

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: dex-server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: repo-server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: 18d0343e68ebe2bdca9559a67e14f9a8b3c9d9ffca6ce3eedf1a09436d02b738
+        checksum/cm: 7ef236d322ec423e6f5ab81361b42bdee38350c027c82e12dfcaea7cf217471c
         checksum/cmd-params: 99c799b5117d4aaf715a43ea51870fc061e85dfffe25a3bb8d6734deb72b190c
       labels:
         app.kubernetes.io/component: application-controller

--- a/manifests/production/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
@@ -148,6 +148,9 @@ data:
         hs.status = "Progressing"
         hs.message = "Waiting for resource to be created"
         return hs
+  resource.customizations.ignoreResourceUpdates.all: |
+    jsonPointers:
+    - /status
   resource.exclusions: |
     - apiGroups:
         - cilium.io


### PR DESCRIPTION
Referencing https://argo-cd.readthedocs.io/en/stable/operator-manual/reconcile/#system-level-configuration and https://github.com/argoproj/argo-cd/issues/9014, this configures ArgoCD to ignore status updates when reconciling resources which significantly reduces CPU usage when an operator updates a status field frequently.