### PR TITLE
fix(kubernetes-dashboard): Use a Backend on SecurityPolicy

### DIFF
--- a/manifests/production/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_backend_keycloak.yaml
+++ b/manifests/production/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_backend_keycloak.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: keycloak
+  namespace: kubernetes-dashboard
+spec:
+  endpoints:
+  - fqdn:
+      hostname: auth.seigra.net
+      port: 443

--- a/manifests/production/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_securitypolicy_kubernetes-dashboard.yaml
+++ b/manifests/production/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_securitypolicy_kubernetes-dashboard.yaml
@@ -14,6 +14,10 @@ spec:
     forwardAccessToken: true
     provider:
       authorizationEndpoint: https://auth.seigra.net/realms/home/protocol/openid-connect/auth
+      backendRefs:
+      - group: gateway.envoyproxy.io
+        kind: Backend
+        name: keycloak
       issuer: https://auth.seigra.net/realms/home
       tokenEndpoint: https://auth.seigra.net/realms/home/protocol/openid-connect/token
     refreshToken: true

--- a/platform/kubernetes-dashboard/base/backend.yaml
+++ b/platform/kubernetes-dashboard/base/backend.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   endpoints:
   - fqdn:
-      hostname: auth.172.18.0.4.nip.io
+      hostname: auth.seigra.net
       port: 443

--- a/platform/kubernetes-dashboard/base/kustomization.yaml
+++ b/platform/kubernetes-dashboard/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - gateway.yaml
 - httproute.yaml
 - securitypolicy.yaml
+- backend.yaml
 - keycloak/client.yaml
 - keycloak/protocolmapper.yaml
 - keycloak/rolemapper.yaml

--- a/platform/kubernetes-dashboard/base/securitypolicy.yaml
+++ b/platform/kubernetes-dashboard/base/securitypolicy.yaml
@@ -9,6 +9,10 @@ spec:
     name: kubernetes-dashboard
   oidc:
     provider:
+      backendRefs:
+      - group: gateway.envoyproxy.io
+        kind: Backend
+        name: keycloak
       authorizationEndpoint: https://auth.seigra.net/realms/home/protocol/openid-connect/auth
       tokenEndpoint: https://auth.seigra.net/realms/home/protocol/openid-connect/token
       issuer: https://auth.seigra.net/realms/home

--- a/platform/kubernetes-dashboard/kind/kustomization.yaml
+++ b/platform/kubernetes-dashboard/kind/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 
 resources:
 - ../base
-- backend.yaml
 - backendtlspolicy.yaml
 - bundle.yaml
 - secrets/csrf.yaml
@@ -16,6 +15,9 @@ patches:
 - path: patches/securitypolicy.yaml
   target:
     kind: SecurityPolicy
+- path: patches/backend.yaml
+  target:
+    kind: Backend
 
 replacements:
 - source:

--- a/platform/kubernetes-dashboard/kind/patches/backend.yaml
+++ b/platform/kubernetes-dashboard/kind/patches/backend.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/json-patch
+- op: replace
+  path: /spec/endpoints/0/fqdn/hostname
+  value: auth.172.18.0.4.nip.io

--- a/platform/kubernetes-dashboard/kind/patches/securitypolicy.yaml
+++ b/platform/kubernetes-dashboard/kind/patches/securitypolicy.yaml
@@ -8,9 +8,3 @@
 - op: replace
   path: /spec/oidc/provider/issuer
   value: https://auth.172.18.0.4.nip.io/realms/home
-- op: add
-  path: /spec/oidc/provider/backendRefs
-  value:
-  - group: gateway.envoyproxy.io
-    kind: Backend
-    name: keycloak


### PR DESCRIPTION
Uses a `Backend` referenced in `SecurityPolicy` OIDC configuration across all environments, not just where a `BackendTLSPolicy` is needed.