### PR TITLE
feat(metallb): Configure metallb for Kind cluster

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,18 +19,31 @@ includes:
 
 tasks:
   clusters:kind:create:
-    cmds:
-    - kind create cluster --config clusters/kind/kind-config.yaml
-    - docker run -d --name cloud-provider-kind --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock registry.k8s.io/cloud-provider-kind/cloud-controller-manager:v0.5.0
+    aliases: [up]
     status:
     - kind get clusters | grep ^kind$
+    cmds:
+    - kind create cluster --config clusters/kind/kind-config.yaml
+    - task: deploy
+      vars:
+        MANIFESTS:
+        - manifests/kind/infrastructure/controllers/metallb
+        - manifests/kind/infrastructure/configs/ipam
 
   clusters:kind:delete:
-    cmds:
-    - kind delete cluster
-    - docker stop cloud-provider-kind
+    aliases: [down]
     status:
     - '! kind get clusters | grep ^kind$'
+    cmd: kind delete cluster
+
+  deploy:
+    vars:
+      MANIFESTS: '{{ join " " .MANIFESTS | default .CLI_ARGS }}'
+    status:
+    - kubectl diff -f {{ splitList " " .MANIFESTS | join " -f " }}
+    cmds:
+    - for: {var: MANIFESTS}
+      cmd: kapp deploy -y -a {{ base .ITEM }} -f {{ .ITEM }}
 
   build *:
     vars:
@@ -48,7 +61,7 @@ tasks:
     cmds:
     - rm -rf {{ .OUTDIR }}/**
     - mkdir -p {{ .OUTDIR }}
-    - kustomize build --enable-helm --enable-alpha-plugins {{ .KUSTOMIZATION }} -o {{ .OUTDIR }}/
+    - kustomize build --load-restrictor LoadRestrictionsNone --enable-helm --enable-alpha-plugins {{ .KUSTOMIZATION }} -o {{ .OUTDIR }}/
     # Replace colons with dashes in filenames
     - find {{ .OUTDIR }} -name '*:*' -exec bash -c 'mv $0 $(echo $0 | tr ":" "-")' {} \;
     internal: true

--- a/apps/actual/kind/kustomization.yaml
+++ b/apps/actual/kind/kustomization.yaml
@@ -14,11 +14,4 @@ patches:
     kind: Gateway
 
 replacements:
-- source:
-    kind: Gateway
-    fieldPath: spec.listeners.0.hostname
-  targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
+- path: ../../../shared/replacements/gateway-hostnames.yaml

--- a/apps/actual/kind/patches/gateway.yaml
+++ b/apps/actual/kind/patches/gateway.yaml
@@ -4,4 +4,9 @@
   value: cluster-ca
 - op: replace
   path: /spec/listeners/0/hostname
-  value: actual.10.5.0.16.nip.io
+  value: actual.172.18.0.9.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.9

--- a/apps/paperless-ngx/kind/kustomization.yaml
+++ b/apps/paperless-ngx/kind/kustomization.yaml
@@ -15,22 +15,11 @@ patches:
     kind: Gateway
 
 replacements:
+- path: ../../../shared/replacements/gateway-hostnames.yaml
 - source:
     kind: Gateway
     fieldPath: spec.listeners.0.hostname
   targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
-  - select:
-      kind: Client
-    fieldPaths:
-    - spec.forProvider.rootUrl
-    - spec.forProvider.validRedirectUris.*
-    options:
-      delimiter: '/'
-      index: 2
   - select:
       kind: ConfigMap
       name: paperless-ngx-config

--- a/apps/paperless-ngx/kind/patches/gateway.yaml
+++ b/apps/paperless-ngx/kind/patches/gateway.yaml
@@ -4,4 +4,9 @@
   value: cluster-ca
 - op: replace
   path: /spec/listeners/0/hostname
-  value: paperless.10.5.0.15.nip.io
+  value: paperless.172.18.0.8.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.8

--- a/infrastructure/configs/ipam/kind/announcement.yaml
+++ b/infrastructure/configs/ipam/kind/announcement.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kind
+spec:
+  ipAddressPools:
+  - kind

--- a/infrastructure/configs/ipam/kind/kustomization.yaml
+++ b/infrastructure/configs/ipam/kind/kustomization.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: metallb-system
+
+resources:
+- pool.yaml
+- announcement.yaml

--- a/infrastructure/configs/ipam/kind/pool.yaml
+++ b/infrastructure/configs/ipam/kind/pool.yaml
@@ -1,0 +1,7 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: kind
+spec:
+  addresses:
+  - 172.18.0.0/16

--- a/infrastructure/controllers/argocd/kind/kustomization.yaml
+++ b/infrastructure/controllers/argocd/kind/kustomization.yaml
@@ -16,19 +16,4 @@ patches:
     name: argocd
 
 replacements:
-- source:
-    kind: Gateway
-    fieldPath: spec.listeners.0.hostname
-  targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
-  - select:
-      kind: Client
-    fieldPaths:
-    - spec.forProvider.rootUrl
-    - spec.forProvider.validRedirectUris.*
-    options:
-      delimiter: '/'
-      index: 2
+- path: ../../../../shared/replacements/gateway-hostnames.yaml

--- a/infrastructure/controllers/argocd/kind/patches/gateway.yaml
+++ b/infrastructure/controllers/argocd/kind/patches/gateway.yaml
@@ -1,7 +1,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
-  path: /spec/listeners/0/hostname
-  value: argocd.172.18.0.6.nip.io
-- op: replace
   path: /metadata/annotations/cert-manager.io~1cluster-issuer
   value: cluster-ca
+- op: replace
+  path: /spec/listeners/0/hostname
+  value: argocd.172.18.0.6.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.6

--- a/infrastructure/controllers/coredns-external/kind/kustomization.yaml
+++ b/infrastructure/controllers/coredns-external/kind/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 
 resources:
 - ../base
+
+patches:
+- path: patches/service.yaml

--- a/infrastructure/controllers/coredns-external/kind/patches/service.yaml
+++ b/infrastructure/controllers/coredns-external/kind/patches/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+  namespace: coredns-external
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 172.18.0.3

--- a/infrastructure/controllers/metallb/kind/kustomization.yaml
+++ b/infrastructure/controllers/metallb/kind/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: metallb-system
+
+resources:
+- https://github.com/metallb/metallb/config/native?ref=v0.14.9

--- a/manifests/kind/apps/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
+++ b/manifests/kind/apps/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
@@ -11,8 +11,11 @@ metadata:
   namespace: actual
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.9
   listeners:
-  - hostname: actual.10.5.0.16.nip.io
+  - hostname: actual.172.18.0.9.nip.io
     name: actual
     port: 443
     protocol: HTTPS

--- a/manifests/kind/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
+++ b/manifests/kind/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: actual
 spec:
   hostnames:
-  - actual.10.5.0.16.nip.io
+  - actual.172.18.0.9.nip.io
   parentRefs:
   - kind: Gateway
     name: actual

--- a/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -62,7 +62,7 @@ spec:
               name: paperless-ngx-db-app
         envFrom:
         - configMapRef:
-            name: paperless-ngx-config-mk6fh78mc5
+            name: paperless-ngx-config-67775hcgd5
         - secretRef:
             name: paperless-ngx-secret-key
         - secretRef:

--- a/manifests/kind/apps/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
@@ -12,11 +12,14 @@ metadata:
   namespace: paperless-ngx
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.8
   listeners:
   - allowedRoutes:
       namespaces:
         from: Same
-    hostname: paperless.10.5.0.15.nip.io
+    hostname: paperless.172.18.0.8.nip.io
     name: paperless-ngx
     port: 443
     protocol: HTTPS

--- a/manifests/kind/apps/paperless-ngx/gateway.networking.k8s.io_v1_httproute_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/gateway.networking.k8s.io_v1_httproute_paperless-ngx.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: paperless-ngx
 spec:
   hostnames:
-  - paperless.10.5.0.15.nip.io
+  - paperless.172.18.0.8.nip.io
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/manifests/kind/apps/paperless-ngx/openidclient.keycloak.crossplane.io_v1alpha1_client_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/openidclient.keycloak.crossplane.io_v1alpha1_client_paperless-ngx.yaml
@@ -15,9 +15,9 @@ spec:
     clientId: paperless-ngx
     realmIdRef:
       name: home
-    rootUrl: https://paperless.10.5.0.15.nip.io
+    rootUrl: https://paperless.172.18.0.8.nip.io
     standardFlowEnabled: true
     validRedirectUris:
-    - https://paperless.10.5.0.15.nip.io/accounts/oidc/keycloak/login/callback/
+    - https://paperless.172.18.0.8.nip.io/accounts/oidc/keycloak/login/callback/
   publishConnectionDetailsTo:
     name: keycloak-client-paperless-ngx

--- a/manifests/kind/apps/paperless-ngx/v1_configmap_paperless-ngx-config-67775hcgd5.yaml
+++ b/manifests/kind/apps/paperless-ngx/v1_configmap_paperless-ngx-config-67775hcgd5.yaml
@@ -8,7 +8,7 @@ data:
   PAPERLESS_TIKA_ENABLED: "1"
   PAPERLESS_TIKA_ENDPOINT: http://paperless-ngx-tika:9998
   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-ngx-gotenberg:3000
-  PAPERLESS_URL: https://paperless.10.5.0.15.nip.io
+  PAPERLESS_URL: https://paperless.172.18.0.8.nip.io
   REQUESTS_CA_BUNDLE: /bundle.pem
 kind: ConfigMap
 metadata:
@@ -17,5 +17,5 @@ metadata:
     app.kubernetes.io/instance: paperless-ngx
     app.kubernetes.io/name: paperless-ngx
     app.kubernetes.io/part-of: paperless-ngx
-  name: paperless-ngx-config-mk6fh78mc5
+  name: paperless-ngx-config-67775hcgd5
   namespace: paperless-ngx

--- a/manifests/kind/apps/paperless-ngx/v1_configmap_paperless-ngx-socialaccount-config.yaml
+++ b/manifests/kind/apps/paperless-ngx/v1_configmap_paperless-ngx-socialaccount-config.yaml
@@ -3,7 +3,7 @@ data:
   client_id: paperless-ngx
   name: seigra.net
   provider_id: keycloak
-  server_url: https://paperless.10.5.0.15.nip.io/realms/home/.well-known/openid-configuration
+  server_url: https://paperless.172.18.0.8.nip.io/realms/home/.well-known/openid-configuration
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/kind/infrastructure/configs/ipam/metallb.io_v1beta1_ipaddresspool_kind.yaml
+++ b/manifests/kind/infrastructure/configs/ipam/metallb.io_v1beta1_ipaddresspool_kind.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: kind
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.0.0/16

--- a/manifests/kind/infrastructure/configs/ipam/metallb.io_v1beta1_l2advertisement_kind.yaml
+++ b/manifests/kind/infrastructure/configs/ipam/metallb.io_v1beta1_l2advertisement_kind.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: kind
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - kind

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: argocd
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.6
   listeners:
   - hostname: argocd.172.18.0.6.nip.io
     name: argocd

--- a/manifests/kind/infrastructure/controllers/coredns-external/v1_service_coredns.yaml
+++ b/manifests/kind/infrastructure/controllers/coredns-external/v1_service_coredns.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 172.18.0.3
   labels:
     app.kubernetes.io/instance: coredns
     app.kubernetes.io/name: coredns

--- a/manifests/kind/infrastructure/controllers/metallb/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_metallb-webhook-configuration.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_metallb-webhook-configuration.yaml
@@ -1,0 +1,126 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: metallb-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta2-bgppeer
+  failurePolicy: Fail
+  name: bgppeersvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bgppeers
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-bfdprofile
+  failurePolicy: Fail
+  name: bfdprofilevalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - DELETE
+    resources:
+    - bfdprofiles
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-bgpadvertisement
+  failurePolicy: Fail
+  name: bgpadvertisementvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bgpadvertisements
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-community
+  failurePolicy: Fail
+  name: communityvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - communities
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-ipaddresspool
+  failurePolicy: Fail
+  name: ipaddresspoolvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ipaddresspools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: metallb-webhook-service
+      namespace: metallb-system
+      path: /validate-metallb-io-v1beta1-l2advertisement
+  failurePolicy: Fail
+  name: l2advertisementvalidationwebhook.metallb.io
+  rules:
+  - apiGroups:
+    - metallb.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - l2advertisements
+  sideEffects: None

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bfdprofiles.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bfdprofiles.metallb.io.yaml
@@ -1,0 +1,120 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: bfdprofiles.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: BFDProfile
+    listKind: BFDProfileList
+    plural: bfdprofiles
+    singular: bfdprofile
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.passiveMode
+      name: Passive Mode
+      type: boolean
+    - jsonPath: .spec.transmitInterval
+      name: Transmit Interval
+      type: integer
+    - jsonPath: .spec.receiveInterval
+      name: Receive Interval
+      type: integer
+    - jsonPath: .spec.detectMultiplier
+      name: Multiplier
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BFDProfile represents the settings of the bfd session that can be
+          optionally associated with a BGP session.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BFDProfileSpec defines the desired state of BFDProfile.
+            properties:
+              detectMultiplier:
+                description: |-
+                  Configures the detection multiplier to determine
+                  packet loss. The remote transmission interval will be multiplied
+                  by this value to determine the connection loss detection timer.
+                format: int32
+                maximum: 255
+                minimum: 2
+                type: integer
+              echoInterval:
+                description: |-
+                  Configures the minimal echo receive transmission
+                  interval that this system is capable of handling in milliseconds.
+                  Defaults to 50ms
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+              echoMode:
+                description: |-
+                  Enables or disables the echo transmission mode.
+                  This mode is disabled by default, and not supported on multi
+                  hops setups.
+                type: boolean
+              minimumTtl:
+                description: |-
+                  For multi hop sessions only: configure the minimum
+                  expected TTL for an incoming BFD control packet.
+                format: int32
+                maximum: 254
+                minimum: 1
+                type: integer
+              passiveMode:
+                description: |-
+                  Mark session as passive: a passive session will not
+                  attempt to start the connection and will wait for control packets
+                  from peer before it begins replying.
+                type: boolean
+              receiveInterval:
+                description: |-
+                  The minimum interval that this system is capable of
+                  receiving control packets in milliseconds.
+                  Defaults to 300ms.
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+              transmitInterval:
+                description: |-
+                  The minimum transmission interval (less jitter)
+                  that this system wants to use to send BFD control packets in
+                  milliseconds. Defaults to 300ms
+                format: int32
+                maximum: 60000
+                minimum: 10
+                type: integer
+            type: object
+          status:
+            description: BFDProfileStatus defines the observed state of BFDProfile.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bgpadvertisements.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bgpadvertisements.metallb.io.yaml
@@ -1,0 +1,216 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: bgpadvertisements.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: BGPAdvertisement
+    listKind: BGPAdvertisementList
+    plural: bgpadvertisements
+    singular: bgpadvertisement
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.peers
+      name: Peers
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BGPAdvertisement allows to advertise the IPs coming
+          from the selected IPAddressPools via BGP, setting the parameters of the
+          BGP Advertisement.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPAdvertisementSpec defines the desired state of BGPAdvertisement.
+            properties:
+              aggregationLength:
+                default: 32
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /32s into a larger prefix. Defaults to 32. Works for
+                  IPv4 addresses.
+                format: int32
+                minimum: 1
+                type: integer
+              aggregationLengthV6:
+                default: 128
+                description: The aggregation-length advertisement option lets you
+                  “roll up” the /128s into a larger prefix. Defaults to 128. Works
+                  for IPv6 addresses.
+                format: int32
+                type: integer
+              communities:
+                description: |-
+                  The BGP communities to be associated with the announcement. Each item can be a standard community of the
+                  form 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the
+                  Community CRD.
+                items:
+                  type: string
+                type: array
+              ipAddressPoolSelectors:
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              ipAddressPools:
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
+                items:
+                  type: string
+                type: array
+              localPref:
+                description: |-
+                  The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,
+                  Path with higher localpref is preferred over one with lower localpref.
+                format: int32
+                type: integer
+              nodeSelectors:
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              peers:
+                description: |-
+                  Peers limits the bgppeer to advertise the ips of the selected pools to.
+                  When empty, the loadbalancer IP is announced to all the BGPPeers configured.
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: BGPAdvertisementStatus defines the observed state of BGPAdvertisement.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bgppeers.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_bgppeers.metallb.io.yaml
@@ -1,0 +1,361 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: bgppeers.metallb.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlGWlRDQ0EwMmdBd0lCQWdJVU5GRW1XcTM3MVpKdGkrMmlSQzk1WmpBV1MxZ3dEUVlKS29aSWh2Y05BUUVMDQpCUUF3UWpFTE1Ba0dBMVVFQmhNQ1dGZ3hGVEFUQmdOVkJBY01ERVJsWm1GMWJIUWdRMmwwZVRFY01Cb0dBMVVFDQpDZ3dUUkdWbVlYVnNkQ0JEYjIxd1lXNTVJRXgwWkRBZUZ3MHlNakEzTVRrd09UTXlNek5hRncweU1qQTRNVGd3DQpPVE15TXpOYU1FSXhDekFKQmdOVkJBWVRBbGhZTVJVd0V3WURWUVFIREF4RVpXWmhkV3gwSUVOcGRIa3hIREFhDQpCZ05WQkFvTUUwUmxabUYxYkhRZ1EyOXRjR0Z1ZVNCTWRHUXdnZ0lpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElDDQpEd0F3Z2dJS0FvSUNBUUNxVFpxMWZRcC9vYkdlenhES0o3OVB3Ny94azJwellualNzMlkzb1ZYSm5sRmM4YjVlDQpma2ZZQnY2bndscW1keW5PL2phWFBaQmRQSS82aFdOUDBkdVhadEtWU0NCUUpyZzEyOGNXb3F0MGNTN3pLb1VpDQpvcU1tQ0QvRXVBeFFNZjhRZDF2c1gvVllkZ0poVTZBRXJLZEpIaXpFOUJtUkNkTDBGMW1OVW55Rk82UnRtWFZUDQpidkxsTDVYeTc2R0FaQVBLOFB4aVlDa0NtbDdxN0VnTWNiOXlLWldCYmlxQ3VkTXE5TGJLNmdKNzF6YkZnSXV4DQo1L1pXK2JraTB2RlplWk9ZODUxb1psckFUNzJvMDI4NHNTWW9uN0pHZVZkY3NoUnh5R1VpSFpSTzdkaXZVTDVTDQpmM2JmSDFYbWY1ZDQzT0NWTWRuUUV2NWVaOG8zeWVLa3ZrbkZQUGVJMU9BbjdGbDlFRVNNR2dhOGFaSG1URSttDQpsLzlMSmdDYjBnQmtPT0M0WnV4bWh2aERKV1EzWnJCS3pMQlNUZXN0NWlLNVlwcXRWVVk2THRyRW9FelVTK1lsDQpwWndXY2VQWHlHeHM5ZURsR3lNVmQraW15Y3NTU1UvVno2Mmx6MnZCS21NTXBkYldDQWhud0RsRTVqU2dyMjRRDQp0eGNXLys2N3d5KzhuQlI3UXdqVTFITndVRjBzeERWdEwrZ1NHVERnSEVZSlhZelYvT05zMy94TkpoVFNPSkxNDQpoeXNVdyttaGdackdhbUdXcHVIVU1DUitvTWJzMTc1UkcrQjJnUFFHVytPTjJnUTRyOXN2b0ZBNHBBQm8xd1dLDQpRYjRhY3pmeVVscElBOVFoSmFsZEY3S3dPSHVlV3gwRUNrNXg0T2tvVDBvWVp0dzFiR0JjRGtaSmF3SURBUUFCDQpvMU13VVRBZEJnTlZIUTRFRmdRVW90UlNIUm9IWTEyRFZ4R0NCdEhpb1g2ZmVFQXdId1lEVlIwakJCZ3dGb0FVDQpvdFJTSFJvSFkxMkRWeEdDQnRIaW9YNmZlRUF3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCDQpBUXNGQUFPQ0FnRUFSbkpsWWRjMTFHd0VxWnh6RDF2R3BDR2pDN2VWTlQ3aVY1d3IybXlybHdPYi9aUWFEa0xYDQpvVStaOVVXT1VlSXJTdzUydDdmQUpvVVAwSm5iYkMveVIrU1lqUGhvUXNiVHduOTc2ZldBWTduM3FMOXhCd1Y0DQphek41OXNjeUp0dlhMeUtOL2N5ak1ReDRLajBIMFg0bWJ6bzVZNUtzWWtYVU0vOEFPdWZMcEd0S1NGVGgrSEFDDQpab1Q5YnZHS25adnNHd0tYZFF0Wnh0akhaUjVqK3U3ZGtQOTJBT051RFNabS8rWVV4b2tBK09JbzdSR3BwSHNXDQo1ZTdNY0FTVXRtb1FORXd6dVFoVkJaRWQ1OGtKYjUrV0VWbGNzanlXNnRTbzErZ25tTWNqR1BsMWgxR2hVbjV4DQpFY0lWRnBIWXM5YWo1NmpBSjk1MVQvZjhMaWxmTlVnanBLQ0c1bnl0SUt3emxhOHNtdGlPdm1UNEpYbXBwSkI2DQo4bmdHRVluVjUrUTYwWFJ2OEhSSGp1VG9CRHVhaERrVDA2R1JGODU1d09FR2V4bkZpMXZYWUxLVllWb1V2MXRKDQo4dVdUR1pwNllDSVJldlBqbzg5ZytWTlJSaVFYUThJd0dybXE5c0RoVTlqTjA0SjdVL1RvRDFpNHE3VnlsRUc5DQorV1VGNkNLaEdBeTJIaEhwVncyTGFoOS9lUzdZMUZ1YURrWmhPZG1laG1BOCtqdHNZamJadnR5Mm1SWlF0UUZzDQpUU1VUUjREbUR2bVVPRVRmeStpRHdzK2RkWXVNTnJGeVVYV2dkMnpBQU4ydVl1UHFGY2pRcFNPODFzVTJTU3R3DQoxVzAyeUtYOGJEYmZFdjBzbUh3UzliQnFlSGo5NEM1Mjg0YXpsdTBmaUdpTm1OUEM4ckJLRmhBPQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+        service:
+          name: metallb-webhook-service
+          namespace: metallb-system
+          path: /convert
+      conversionReviewVersions:
+      - v1beta1
+      - v1beta2
+  group: metallb.io
+  names:
+    kind: BGPPeer
+    listKind: BGPPeerList
+    plural: bgppeers
+    singular: bgppeer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    deprecated: true
+    deprecationWarning: v1beta1 is deprecated, please use v1beta2
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BGPPeer is the Schema for the peers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec defines the desired state of Peer.
+            properties:
+              bfdProfile:
+                type: string
+              ebgpMultiHop:
+                description: EBGP peer is multi-hops away
+                type: boolean
+              holdTime:
+                description: Requested BGP hold time, per RFC4271.
+                type: string
+              keepaliveTime:
+                description: Requested BGP keepalive time, per RFC4271.
+                type: string
+              myASN:
+                description: AS number to use for the local end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              nodeSelectors:
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
+                items:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        - values
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                type: array
+              password:
+                description: Authentication password for routers enforcing TCP MD5
+                  authenticated sessions
+                type: string
+              peerASN:
+                description: AS number to expect from the remote end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              peerAddress:
+                description: Address to dial when establishing the session.
+                type: string
+              peerPort:
+                description: Port to dial when establishing the session.
+                maximum: 16384
+                minimum: 0
+                type: integer
+              routerID:
+                description: BGP router ID to advertise to the peer
+                type: string
+              sourceAddress:
+                description: Source address to use when establishing the session.
+                type: string
+            required:
+            - myASN
+            - peerASN
+            - peerAddress
+            type: object
+          status:
+            description: BGPPeerStatus defines the observed state of Peer.
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.peerAddress
+      name: Address
+      type: string
+    - jsonPath: .spec.peerASN
+      name: ASN
+      type: string
+    - jsonPath: .spec.bfdProfile
+      name: BFD Profile
+      type: string
+    - jsonPath: .spec.ebgpMultiHop
+      name: Multi Hops
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BGPPeer is the Schema for the peers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPPeerSpec defines the desired state of Peer.
+            properties:
+              bfdProfile:
+                description: The name of the BFD Profile to be used for the BFD session
+                  associated to the BGP session. If not set, the BFD session won't
+                  be set up.
+                type: string
+              connectTime:
+                description: Requested BGP connect time, controls how long BGP waits
+                  between connection attempts to a neighbor.
+                type: string
+                x-kubernetes-validations:
+                - message: connect time should be between 1 seconds to 65535
+                  rule: duration(self).getSeconds() >= 1 && duration(self).getSeconds()
+                    <= 65535
+                - message: connect time should contain a whole number of seconds
+                  rule: duration(self).getMilliseconds() % 1000 == 0
+              disableMP:
+                default: false
+                description: To set if we want to disable MP BGP that will separate
+                  IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                type: boolean
+              dynamicASN:
+                description: |-
+                  DynamicASN detects the AS number to use for the remote end of the session
+                  without explicitly setting it via the ASN field. Limited to:
+                  internal - if the neighbor's ASN is different than MyASN connection is denied.
+                  external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                enum:
+                - internal
+                - external
+                type: string
+              ebgpMultiHop:
+                description: To set if the BGPPeer is multi-hops away. Needed for
+                  FRR mode only.
+                type: boolean
+              enableGracefulRestart:
+                description: |-
+                  EnableGracefulRestart allows BGP peer to continue to forward data packets
+                  along known routes while the routing protocol information is being
+                  restored. This field is immutable because it requires restart of the BGP
+                  session. Supported for FRR mode only.
+                type: boolean
+                x-kubernetes-validations:
+                - message: EnableGracefulRestart cannot be changed after creation
+                  rule: self == oldSelf
+              holdTime:
+                description: Requested BGP hold time, per RFC4271.
+                type: string
+              keepaliveTime:
+                description: Requested BGP keepalive time, per RFC4271.
+                type: string
+              myASN:
+                description: AS number to use for the local end of the session.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              nodeSelectors:
+                description: |-
+                  Only connect to this peer on nodes that match one of these
+                  selectors.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              password:
+                description: Authentication password for routers enforcing TCP MD5
+                  authenticated sessions
+                type: string
+              passwordSecret:
+                description: |-
+                  passwordSecret is name of the authentication secret for BGP Peer.
+                  the secret must be of type "kubernetes.io/basic-auth", and created in the
+                  same namespace as the MetalLB deployment. The password is stored in the
+                  secret as the key "password".
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              peerASN:
+                description: |-
+                  AS number to expect from the remote end of the session.
+                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                format: int32
+                maximum: 4294967295
+                minimum: 0
+                type: integer
+              peerAddress:
+                description: Address to dial when establishing the session.
+                type: string
+              peerPort:
+                default: 179
+                description: Port to dial when establishing the session.
+                maximum: 16384
+                minimum: 0
+                type: integer
+              routerID:
+                description: BGP router ID to advertise to the peer
+                type: string
+              sourceAddress:
+                description: Source address to use when establishing the session.
+                type: string
+              vrf:
+                description: |-
+                  To set if we want to peer with the BGPPeer using an interface belonging to
+                  a host vrf
+                type: string
+            required:
+            - myASN
+            - peerAddress
+            type: object
+          status:
+            description: BGPPeerStatus defines the observed state of Peer.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_communities.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_communities.metallb.io.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: communities.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: Community
+    listKind: CommunityList
+    plural: communities
+    singular: community
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Community is a collection of aliases for communities.
+          Users can define named aliases to be used in the BGPPeer CRD.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CommunitySpec defines the desired state of Community.
+            properties:
+              communities:
+                items:
+                  properties:
+                    name:
+                      description: The name of the alias for the community.
+                      type: string
+                    value:
+                      description: |-
+                        The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234
+                        or a large community of the form large:1234:1234:1234.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: CommunityStatus defines the observed state of Community.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_ipaddresspools.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_ipaddresspools.metallb.io.yaml
@@ -1,0 +1,215 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: ipaddresspools.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: IPAddressPool
+    listKind: IPAddressPoolList
+    plural: ipaddresspools
+    singular: ipaddresspool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoAssign
+      name: Auto Assign
+      type: boolean
+    - jsonPath: .spec.avoidBuggyIPs
+      name: Avoid Buggy IPs
+      type: boolean
+    - jsonPath: .spec.addresses
+      name: Addresses
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          IPAddressPool represents a pool of IP addresses that can be allocated
+          to LoadBalancer services.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAddressPoolSpec defines the desired state of IPAddressPool.
+            properties:
+              addresses:
+                description: |-
+                  A list of IP address ranges over which MetalLB has authority.
+                  You can list multiple ranges in a single pool, they will all share the
+                  same settings. Each range can be either a CIDR prefix, or an explicit
+                  start-end range of IPs.
+                items:
+                  type: string
+                type: array
+              autoAssign:
+                default: true
+                description: |-
+                  AutoAssign flag used to prevent MetallB from automatic allocation
+                  for a pool.
+                type: boolean
+              avoidBuggyIPs:
+                default: false
+                description: |-
+                  AvoidBuggyIPs prevents addresses ending with .0 and .255
+                  to be used by a pool.
+                type: boolean
+              serviceAllocation:
+                description: |-
+                  AllocateTo makes ip pool allocation to specific namespace and/or service.
+                  The controller will use the pool with lowest value of priority in case of
+                  multiple matches. A pool with no priority set will be used only if the
+                  pools with priority can't be used. If multiple matching IPAddressPools are
+                  available it will check for the availability of IPs sorting the matching
+                  IPAddressPools by priority, starting from the highest to the lowest. If
+                  multiple IPAddressPools have the same priority, choice will be random.
+                properties:
+                  namespaceSelectors:
+                    description: |-
+                      NamespaceSelectors list of label selectors to select namespace(s) for ip pool,
+                      an alternative to using namespace list.
+                    items:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  namespaces:
+                    description: Namespaces list of namespace(s) on which ip pool
+                      can be attached.
+                    items:
+                      type: string
+                    type: array
+                  priority:
+                    description: Priority priority given for ip pool while ip allocation
+                      on a service.
+                    type: integer
+                  serviceSelectors:
+                    description: |-
+                      ServiceSelectors list of label selector to select service(s) for which ip pool
+                      can be used for ip allocation.
+                    items:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+            required:
+            - addresses
+            type: object
+          status:
+            description: IPAddressPoolStatus defines the observed state of IPAddressPool.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_l2advertisements.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_l2advertisements.metallb.io.yaml
@@ -1,0 +1,186 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: l2advertisements.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: L2Advertisement
+    listKind: L2AdvertisementList
+    plural: l2advertisements
+    singular: l2advertisement
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ipAddressPools
+      name: IPAddressPools
+      type: string
+    - jsonPath: .spec.ipAddressPoolSelectors
+      name: IPAddressPool Selectors
+      type: string
+    - jsonPath: .spec.interfaces
+      name: Interfaces
+      type: string
+    - jsonPath: .spec.nodeSelectors
+      name: Node Selectors
+      priority: 10
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          L2Advertisement allows to advertise the LoadBalancer IPs provided
+          by the selected pools via L2.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: L2AdvertisementSpec defines the desired state of L2Advertisement.
+            properties:
+              interfaces:
+                description: |-
+                  A list of interfaces to announce from. The LB IP will be announced only from these interfaces.
+                  If the field is not set, we advertise from all the interfaces on the host.
+                items:
+                  type: string
+                type: array
+              ipAddressPoolSelectors:
+                description: |-
+                  A selector for the IPAddressPools which would get advertised via this advertisement.
+                  If no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              ipAddressPools:
+                description: The list of IPAddressPools to advertise via this advertisement,
+                  selected by name.
+                items:
+                  type: string
+                type: array
+              nodeSelectors:
+                description: NodeSelectors allows to limit the nodes to announce as
+                  next hops for the LoadBalancer IP. When empty, all the nodes having  are
+                  announced as next hops.
+                items:
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+            type: object
+          status:
+            description: L2AdvertisementStatus defines the observed state of L2Advertisement.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_servicel2statuses.metallb.io.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apiextensions.k8s.io_v1_customresourcedefinition_servicel2statuses.metallb.io.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  name: servicel2statuses.metallb.io
+spec:
+  group: metallb.io
+  names:
+    kind: ServiceL2Status
+    listKind: ServiceL2StatusList
+    plural: servicel2statuses
+    singular: servicel2status
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Allocated Node
+      type: string
+    - jsonPath: .status.serviceName
+      name: Service Name
+      type: string
+    - jsonPath: .status.serviceNamespace
+      name: Service Namespace
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceL2Status reveals the actual traffic status of loadbalancer
+          services in layer2 mode.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceL2StatusSpec defines the desired state of ServiceL2Status.
+            type: object
+          status:
+            description: MetalLBServiceL2Status defines the observed state of ServiceL2Status.
+            properties:
+              interfaces:
+                description: Interfaces indicates the interfaces that receive the
+                  directed traffic
+                items:
+                  description: InterfaceInfo defines interface info of layer2 announcement.
+                  properties:
+                    name:
+                      description: Name the name of network interface card
+                      type: string
+                  type: object
+                type: array
+              node:
+                description: Node indicates the node that receives the directed traffic
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceName:
+                description: ServiceName indicates the service this status represents
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              serviceNamespace:
+                description: ServiceNamespace indicates the namespace of the service
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/kind/infrastructure/controllers/metallb/apps_v1_daemonset_speaker.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apps_v1_daemonset_speaker.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "7472"
+        prometheus.io/scrape: "true"
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --log-level=info
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METALLB_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_ML_BIND_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: METALLB_ML_LABELS
+          value: app=metallb,component=speaker
+        - name: METALLB_ML_SECRET_KEY_PATH
+          value: /etc/ml_secret_key
+        image: quay.io/metallb/speaker:v0.14.9
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: monitoring
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        - containerPort: 7946
+          name: memberlist-tcp
+        - containerPort: 7946
+          name: memberlist-udp
+          protocol: UDP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: monitoring
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_RAW
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/ml_secret_key
+          name: memberlist
+          readOnly: true
+        - mountPath: /etc/metallb
+          name: metallb-excludel2
+          readOnly: true
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      volumes:
+      - name: memberlist
+        secret:
+          defaultMode: 420
+          secretName: memberlist
+      - configMap:
+          defaultMode: 256
+          name: metallb-excludel2
+        name: metallb-excludel2

--- a/manifests/kind/infrastructure/controllers/metallb/apps_v1_deployment_controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/apps_v1_deployment_controller.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "7472"
+        prometheus.io/scrape: "true"
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --log-level=info
+        - --tls-min-version=VersionTLS12
+        env:
+        - name: METALLB_ML_SECRET_NAME
+          value: memberlist
+        - name: METALLB_DEPLOYMENT
+          value: controller
+        image: quay.io/metallb/controller:v0.14.9
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: monitoring
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /metrics
+            port: monitoring
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: metallb-webhook-cert

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrole_metallb-system-controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrole_metallb-system-controller.yaml
@@ -1,0 +1,90 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - metallb-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - bfdprofiles.metallb.io
+  - bgpadvertisements.metallb.io
+  - bgppeers.metallb.io
+  - ipaddresspools.metallb.io
+  - l2advertisements.metallb.io
+  - communities.metallb.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrole_metallb-system-speaker.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrole_metallb-system-speaker.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+- apiGroups:
+  - metallb.io
+  resources:
+  - servicel2statuses
+  - servicel2statuses/status
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - nodes
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - policy
+  resourceNames:
+  - speaker
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrolebinding_metallb-system-controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrolebinding_metallb-system-controller.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrolebinding_metallb-system-speaker.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_clusterrolebinding_metallb-system-speaker.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_role_controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_role_controller.yaml
@@ -1,0 +1,83 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - memberlist
+  resources:
+  - secrets
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resourceNames:
+  - controller
+  resources:
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - metallb.io
+  resources:
+  - bgppeers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - metallb.io
+  resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - ipaddresspools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - bgpadvertisements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - l2advertisements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - communities
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_role_pod-lister.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_role_pod-lister.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - bfdprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - bgppeers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - l2advertisements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - bgpadvertisements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - ipaddresspools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metallb.io
+  resources:
+  - communities
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_rolebinding_controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_rolebinding_controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_rolebinding_pod-lister.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/rbac.authorization.k8s.io_v1_rolebinding_pod-lister.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/v1_configmap_metallb-excludel2.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_configmap_metallb-excludel2.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  excludel2.yaml: |
+    announcedInterfacesToExclude: ["^docker.*", "^cbr.*", "^dummy.*", "^virbr.*", "^lxcbr.*", "^veth.*", "^lo$", "^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*", "^nodelocaldns.*"]
+kind: ConfigMap
+metadata:
+  name: metallb-excludel2
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/v1_namespace_metallb-system.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_namespace_metallb-system.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/v1_secret_metallb-webhook-cert.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_secret_metallb-webhook-cert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metallb-webhook-cert
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/v1_service_metallb-webhook-service.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_service_metallb-webhook-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: metallb-webhook-service
+  namespace: metallb-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    component: controller

--- a/manifests/kind/infrastructure/controllers/metallb/v1_serviceaccount_controller.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_serviceaccount_controller.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system

--- a/manifests/kind/infrastructure/controllers/metallb/v1_serviceaccount_speaker.yaml
+++ b/manifests/kind/infrastructure/controllers/metallb/v1_serviceaccount_speaker.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system

--- a/manifests/kind/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
+++ b/manifests/kind/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: keycloak
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.4
   listeners:
   - hostname: auth.172.18.0.4.nip.io
     name: keycloak

--- a/manifests/kind/platform/kubernetes-dashboard/kubernetes-dashboard_gateway.networking.k8s.io_v1_gateway_kubernetes-dashboard.yaml
+++ b/manifests/kind/platform/kubernetes-dashboard/kubernetes-dashboard_gateway.networking.k8s.io_v1_gateway_kubernetes-dashboard.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: kubernetes-dashboard
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.5
   listeners:
   - hostname: k8s.172.18.0.5.nip.io
     name: kubernetes-dashboard

--- a/manifests/kind/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/kind/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   gatewayClassName: envoy-gateway
+  infrastructure:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.7
   listeners:
   - allowedRoutes:
       namespaces:

--- a/platform/idp/kind/kustomization.yaml
+++ b/platform/idp/kind/kustomization.yaml
@@ -25,11 +25,4 @@ patches:
     kind: Gateway
 
 replacements:
-- source:
-    kind: Gateway
-    fieldPath: spec.listeners.0.hostname
-  targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
+- path: ../../../shared/replacements/gateway-hostnames.yaml

--- a/platform/idp/kind/patches/gateway.yaml
+++ b/platform/idp/kind/patches/gateway.yaml
@@ -1,7 +1,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
-  path: /spec/listeners/0/hostname
-  value: auth.172.18.0.4.nip.io
-- op: replace
   path: /metadata/annotations/cert-manager.io~1cluster-issuer
   value: cluster-ca
+- op: replace
+  path: /spec/listeners/0/hostname
+  value: auth.172.18.0.4.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.4

--- a/platform/kubernetes-dashboard/kind/kustomization.yaml
+++ b/platform/kubernetes-dashboard/kind/kustomization.yaml
@@ -18,19 +18,4 @@ patches:
     kind: SecurityPolicy
 
 replacements:
-- source:
-    kind: Gateway
-    fieldPath: spec.listeners.0.hostname
-  targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
-  - select:
-      kind: Client
-    fieldPaths:
-    - spec.forProvider.rootUrl
-    - spec.forProvider.validRedirectUris.*
-    options:
-      delimiter: '/'
-      index: 2
+- path: ../../../shared/replacements/gateway-hostnames.yaml

--- a/platform/kubernetes-dashboard/kind/patches/gateway.yaml
+++ b/platform/kubernetes-dashboard/kind/patches/gateway.yaml
@@ -1,7 +1,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
-  path: /spec/listeners/0/hostname
-  value: k8s.172.18.0.5.nip.io
-- op: replace
   path: /metadata/annotations/cert-manager.io~1cluster-issuer
   value: cluster-ca
+- op: replace
+  path: /spec/listeners/0/hostname
+  value: k8s.172.18.0.5.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.5

--- a/platform/monitoring/kind/kustomization.yaml
+++ b/platform/monitoring/kind/kustomization.yaml
@@ -12,27 +12,4 @@ patches:
     kind: Gateway
 
 replacements:
-- source:
-    kind: Gateway
-    fieldPath: spec.listeners.0.hostname
-  targets:
-  - select:
-      kind: HTTPRoute
-    fieldPaths:
-    - spec.hostnames.0
-  - select:
-      kind: Client
-    fieldPaths:
-    - spec.forProvider.rootUrl
-    - spec.forProvider.validRedirectUris.*
-    options:
-      delimiter: '/'
-      index: 2
-  - select:
-      kind: Client
-    fieldPaths:
-      - spec.forProvider.rootUrl
-      - spec.forProvider.validRedirectUris.*
-    options:
-      delimiter: '/'
-      index: 2
+- path: ../../../shared/replacements/gateway-hostnames.yaml

--- a/platform/monitoring/kind/patches/gateway.yaml
+++ b/platform/monitoring/kind/patches/gateway.yaml
@@ -1,7 +1,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
-  path: /spec/listeners/0/hostname
-  value: grafana.172.18.0.7.nip.io
-- op: replace
   path: /metadata/annotations/cert-manager.io~1cluster-issuer
   value: cluster-ca
+- op: replace
+  path: /spec/listeners/0/hostname
+  value: grafana.172.18.0.7.nip.io
+- op: add
+  path: /spec/infrastructure
+  value:
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: 172.18.0.7

--- a/schemas/metallb.io/bfdprofile_v1beta1.json
+++ b/schemas/metallb.io/bfdprofile_v1beta1.json
@@ -1,0 +1,80 @@
+{
+  "description": "BFDProfile represents the settings of the bfd session that can be\noptionally associated with a BGP session.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BFDProfileSpec defines the desired state of BFDProfile.",
+      "properties": {
+        "detectMultiplier": {
+          "description": "Configures the detection multiplier to determine\npacket loss. The remote transmission interval will be multiplied\nby this value to determine the connection loss detection timer.",
+          "format": "int32",
+          "maximum": 255,
+          "minimum": 2,
+          "type": "integer"
+        },
+        "echoInterval": {
+          "description": "Configures the minimal echo receive transmission\ninterval that this system is capable of handling in milliseconds.\nDefaults to 50ms",
+          "format": "int32",
+          "maximum": 60000,
+          "minimum": 10,
+          "type": "integer"
+        },
+        "echoMode": {
+          "description": "Enables or disables the echo transmission mode.\nThis mode is disabled by default, and not supported on multi\nhops setups.",
+          "type": "boolean"
+        },
+        "minimumTtl": {
+          "description": "For multi hop sessions only: configure the minimum\nexpected TTL for an incoming BFD control packet.",
+          "format": "int32",
+          "maximum": 254,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "passiveMode": {
+          "description": "Mark session as passive: a passive session will not\nattempt to start the connection and will wait for control packets\nfrom peer before it begins replying.",
+          "type": "boolean"
+        },
+        "receiveInterval": {
+          "description": "The minimum interval that this system is capable of\nreceiving control packets in milliseconds.\nDefaults to 300ms.",
+          "format": "int32",
+          "maximum": 60000,
+          "minimum": 10,
+          "type": "integer"
+        },
+        "transmitInterval": {
+          "description": "The minimum transmission interval (less jitter)\nthat this system wants to use to send BFD control packets in\nmilliseconds. Defaults to 300ms",
+          "format": "int32",
+          "maximum": 60000,
+          "minimum": 10,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "BFDProfileStatus defines the observed state of BFDProfile.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "BFDProfile"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/bgpadvertisement_v1beta1.json
+++ b/schemas/metallb.io/bgpadvertisement_v1beta1.json
@@ -1,0 +1,174 @@
+{
+  "description": "BGPAdvertisement allows to advertise the IPs coming\nfrom the selected IPAddressPools via BGP, setting the parameters of the\nBGP Advertisement.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BGPAdvertisementSpec defines the desired state of BGPAdvertisement.",
+      "properties": {
+        "aggregationLength": {
+          "default": 32,
+          "description": "The aggregation-length advertisement option lets you \u201croll up\u201d the /32s into a larger prefix. Defaults to 32. Works for IPv4 addresses.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "aggregationLengthV6": {
+          "default": 128,
+          "description": "The aggregation-length advertisement option lets you \u201croll up\u201d the /128s into a larger prefix. Defaults to 128. Works for IPv6 addresses.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "communities": {
+          "description": "The BGP communities to be associated with the announcement. Each item can be a standard community of the\nform 1234:1234, a large community of the form large:1234:1234:1234 or the name of an alias defined in the\nCommunity CRD.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ipAddressPoolSelectors": {
+          "description": "A selector for the IPAddressPools which would get advertised via this advertisement.\nIf no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic"
+          },
+          "type": "array"
+        },
+        "ipAddressPools": {
+          "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "localPref": {
+          "description": "The BGP LOCAL_PREF attribute which is used by BGP best path algorithm,\nPath with higher localpref is preferred over one with lower localpref.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "nodeSelectors": {
+          "description": "NodeSelectors allows to limit the nodes to announce as next hops for the LoadBalancer IP. When empty, all the nodes having  are announced as next hops.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic"
+          },
+          "type": "array"
+        },
+        "peers": {
+          "description": "Peers limits the bgppeer to advertise the ips of the selected pools to.\nWhen empty, the loadbalancer IP is announced to all the BGPPeers configured.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "BGPAdvertisementStatus defines the observed state of BGPAdvertisement.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "BGPAdvertisement"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/bgppeer_v1beta1.json
+++ b/schemas/metallb.io/bgppeer_v1beta1.json
@@ -1,0 +1,134 @@
+{
+  "description": "BGPPeer is the Schema for the peers API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BGPPeerSpec defines the desired state of Peer.",
+      "properties": {
+        "bfdProfile": {
+          "type": "string"
+        },
+        "ebgpMultiHop": {
+          "description": "EBGP peer is multi-hops away",
+          "type": "boolean"
+        },
+        "holdTime": {
+          "description": "Requested BGP hold time, per RFC4271.",
+          "type": "string"
+        },
+        "keepaliveTime": {
+          "description": "Requested BGP keepalive time, per RFC4271.",
+          "type": "string"
+        },
+        "myASN": {
+          "description": "AS number to use for the local end of the session.",
+          "format": "int32",
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nodeSelectors": {
+          "description": "Only connect to this peer on nodes that match one of these\nselectors.",
+          "items": {
+            "properties": {
+              "matchExpressions": {
+                "items": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator",
+                    "values"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "password": {
+          "description": "Authentication password for routers enforcing TCP MD5 authenticated sessions",
+          "type": "string"
+        },
+        "peerASN": {
+          "description": "AS number to expect from the remote end of the session.",
+          "format": "int32",
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "peerAddress": {
+          "description": "Address to dial when establishing the session.",
+          "type": "string"
+        },
+        "peerPort": {
+          "description": "Port to dial when establishing the session.",
+          "maximum": 16384,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "routerID": {
+          "description": "BGP router ID to advertise to the peer",
+          "type": "string"
+        },
+        "sourceAddress": {
+          "description": "Source address to use when establishing the session.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "myASN",
+        "peerASN",
+        "peerAddress"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "BGPPeerStatus defines the observed state of Peer.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "BGPPeer"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/bgppeer_v1beta2.json
+++ b/schemas/metallb.io/bgppeer_v1beta2.json
@@ -1,0 +1,199 @@
+{
+  "description": "BGPPeer is the Schema for the peers API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BGPPeerSpec defines the desired state of Peer.",
+      "properties": {
+        "bfdProfile": {
+          "description": "The name of the BFD Profile to be used for the BFD session associated to the BGP session. If not set, the BFD session won't be set up.",
+          "type": "string"
+        },
+        "connectTime": {
+          "description": "Requested BGP connect time, controls how long BGP waits between connection attempts to a neighbor.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "connect time should be between 1 seconds to 65535",
+              "rule": "duration(self).getSeconds() >= 1 && duration(self).getSeconds() <= 65535"
+            },
+            {
+              "message": "connect time should contain a whole number of seconds",
+              "rule": "duration(self).getMilliseconds() % 1000 == 0"
+            }
+          ]
+        },
+        "disableMP": {
+          "default": false,
+          "description": "To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.",
+          "type": "boolean"
+        },
+        "dynamicASN": {
+          "description": "DynamicASN detects the AS number to use for the remote end of the session\nwithout explicitly setting it via the ASN field. Limited to:\ninternal - if the neighbor's ASN is different than MyASN connection is denied.\nexternal - if the neighbor's ASN is the same as MyASN the connection is denied.\nASN and DynamicASN are mutually exclusive and one of them must be specified.",
+          "enum": [
+            "internal",
+            "external"
+          ],
+          "type": "string"
+        },
+        "ebgpMultiHop": {
+          "description": "To set if the BGPPeer is multi-hops away. Needed for FRR mode only.",
+          "type": "boolean"
+        },
+        "enableGracefulRestart": {
+          "description": "EnableGracefulRestart allows BGP peer to continue to forward data packets\nalong known routes while the routing protocol information is being\nrestored. This field is immutable because it requires restart of the BGP\nsession. Supported for FRR mode only.",
+          "type": "boolean",
+          "x-kubernetes-validations": [
+            {
+              "message": "EnableGracefulRestart cannot be changed after creation",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "holdTime": {
+          "description": "Requested BGP hold time, per RFC4271.",
+          "type": "string"
+        },
+        "keepaliveTime": {
+          "description": "Requested BGP keepalive time, per RFC4271.",
+          "type": "string"
+        },
+        "myASN": {
+          "description": "AS number to use for the local end of the session.",
+          "format": "int32",
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nodeSelectors": {
+          "description": "Only connect to this peer on nodes that match one of these\nselectors.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic"
+          },
+          "type": "array"
+        },
+        "password": {
+          "description": "Authentication password for routers enforcing TCP MD5 authenticated sessions",
+          "type": "string"
+        },
+        "passwordSecret": {
+          "description": "passwordSecret is name of the authentication secret for BGP Peer.\nthe secret must be of type \"kubernetes.io/basic-auth\", and created in the\nsame namespace as the MetalLB deployment. The password is stored in the\nsecret as the key \"password\".",
+          "properties": {
+            "name": {
+              "description": "name is unique within a namespace to reference a secret resource.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "namespace defines the space within which the secret name must be unique.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
+        },
+        "peerASN": {
+          "description": "AS number to expect from the remote end of the session.\nASN and DynamicASN are mutually exclusive and one of them must be specified.",
+          "format": "int32",
+          "maximum": 4294967295,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "peerAddress": {
+          "description": "Address to dial when establishing the session.",
+          "type": "string"
+        },
+        "peerPort": {
+          "default": 179,
+          "description": "Port to dial when establishing the session.",
+          "maximum": 16384,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "routerID": {
+          "description": "BGP router ID to advertise to the peer",
+          "type": "string"
+        },
+        "sourceAddress": {
+          "description": "Source address to use when establishing the session.",
+          "type": "string"
+        },
+        "vrf": {
+          "description": "To set if we want to peer with the BGPPeer using an interface belonging to\na host vrf",
+          "type": "string"
+        }
+      },
+      "required": [
+        "myASN",
+        "peerAddress"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "BGPPeerStatus defines the observed state of Peer.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "BGPPeer"
+      ],
+      "version": "v1beta2",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/community_v1beta1.json
+++ b/schemas/metallb.io/community_v1beta1.json
@@ -1,0 +1,53 @@
+{
+  "description": "Community is a collection of aliases for communities.\nUsers can define named aliases to be used in the BGPPeer CRD.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "CommunitySpec defines the desired state of Community.",
+      "properties": {
+        "communities": {
+          "items": {
+            "properties": {
+              "name": {
+                "description": "The name of the alias for the community.",
+                "type": "string"
+              },
+              "value": {
+                "description": "The BGP community value corresponding to the given name. Can be a standard community of the form 1234:1234\nor a large community of the form large:1234:1234:1234.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "CommunityStatus defines the observed state of Community.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "Community"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/ipaddresspool_v1beta1.json
+++ b/schemas/metallb.io/ipaddresspool_v1beta1.json
@@ -1,0 +1,175 @@
+{
+  "description": "IPAddressPool represents a pool of IP addresses that can be allocated\nto LoadBalancer services.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "IPAddressPoolSpec defines the desired state of IPAddressPool.",
+      "properties": {
+        "addresses": {
+          "description": "A list of IP address ranges over which MetalLB has authority.\nYou can list multiple ranges in a single pool, they will all share the\nsame settings. Each range can be either a CIDR prefix, or an explicit\nstart-end range of IPs.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "autoAssign": {
+          "default": true,
+          "description": "AutoAssign flag used to prevent MetallB from automatic allocation\nfor a pool.",
+          "type": "boolean"
+        },
+        "avoidBuggyIPs": {
+          "default": false,
+          "description": "AvoidBuggyIPs prevents addresses ending with .0 and .255\nto be used by a pool.",
+          "type": "boolean"
+        },
+        "serviceAllocation": {
+          "description": "AllocateTo makes ip pool allocation to specific namespace and/or service.\nThe controller will use the pool with lowest value of priority in case of\nmultiple matches. A pool with no priority set will be used only if the\npools with priority can't be used. If multiple matching IPAddressPools are\navailable it will check for the availability of IPs sorting the matching\nIPAddressPools by priority, starting from the highest to the lowest. If\nmultiple IPAddressPools have the same priority, choice will be random.",
+          "properties": {
+            "namespaceSelectors": {
+              "description": "NamespaceSelectors list of label selectors to select namespace(s) for ip pool,\nan alternative to using namespace list.",
+              "items": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic"
+              },
+              "type": "array"
+            },
+            "namespaces": {
+              "description": "Namespaces list of namespace(s) on which ip pool can be attached.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "priority": {
+              "description": "Priority priority given for ip pool while ip allocation on a service.",
+              "type": "integer"
+            },
+            "serviceSelectors": {
+              "description": "ServiceSelectors list of label selector to select service(s) for which ip pool\ncan be used for ip allocation.",
+              "items": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "addresses"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "IPAddressPoolStatus defines the observed state of IPAddressPool.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "IPAddressPool"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/l2advertisement_v1beta1.json
+++ b/schemas/metallb.io/l2advertisement_v1beta1.json
@@ -1,0 +1,149 @@
+{
+  "description": "L2Advertisement allows to advertise the LoadBalancer IPs provided\nby the selected pools via L2.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "L2AdvertisementSpec defines the desired state of L2Advertisement.",
+      "properties": {
+        "interfaces": {
+          "description": "A list of interfaces to announce from. The LB IP will be announced only from these interfaces.\nIf the field is not set, we advertise from all the interfaces on the host.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ipAddressPoolSelectors": {
+          "description": "A selector for the IPAddressPools which would get advertised via this advertisement.\nIf no IPAddressPool is selected by this or by the list, the advertisement is applied to all the IPAddressPools.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic"
+          },
+          "type": "array"
+        },
+        "ipAddressPools": {
+          "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nodeSelectors": {
+          "description": "NodeSelectors allows to limit the nodes to announce as next hops for the LoadBalancer IP. When empty, all the nodes having  are announced as next hops.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "L2AdvertisementStatus defines the observed state of L2Advertisement.",
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "L2Advertisement"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/schemas/metallb.io/servicel2status_v1beta1.json
+++ b/schemas/metallb.io/servicel2status_v1beta1.json
@@ -1,0 +1,81 @@
+{
+  "description": "ServiceL2Status reveals the actual traffic status of loadbalancer services in layer2 mode.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ServiceL2StatusSpec defines the desired state of ServiceL2Status.",
+      "type": "object"
+    },
+    "status": {
+      "description": "MetalLBServiceL2Status defines the observed state of ServiceL2Status.",
+      "properties": {
+        "interfaces": {
+          "description": "Interfaces indicates the interfaces that receive the directed traffic",
+          "items": {
+            "description": "InterfaceInfo defines interface info of layer2 announcement.",
+            "properties": {
+              "name": {
+                "description": "Name the name of network interface card",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "node": {
+          "description": "Node indicates the node that receives the directed traffic",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "serviceName": {
+          "description": "ServiceName indicates the service this status represents",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "serviceNamespace": {
+          "description": "ServiceNamespace indicates the namespace of the service",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object",
+  "x-kubernetes-group-version-kind": [
+    {
+      "kind": [
+        "ServiceL2Status"
+      ],
+      "version": "v1beta1",
+      "group": "metallb.io"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/shared/replacements/gateway-hostnames.yaml
+++ b/shared/replacements/gateway-hostnames.yaml
@@ -1,0 +1,16 @@
+source:
+  kind: Gateway
+  fieldPath: spec.listeners.0.hostname
+targets:
+- select:
+    kind: HTTPRoute
+  fieldPaths:
+  - spec.hostnames.0
+- select:
+    kind: Client
+  fieldPaths:
+  - spec.forProvider.rootUrl
+  - spec.forProvider.validRedirectUris.*
+  options:
+    delimiter: '/'
+    index: 2


### PR DESCRIPTION
This switches from [cloud-provider-kind](https://github.com/kubernetes-sigs/cloud-provider-kind) to using MetalLB in the Kind cluster. This allows specific IPs to be requested in service annotations, allowing for stable use of '.nip.io' domains for development.

Additionally, this updates all existing Gateway and LoadBalancer services to use unique IPs and generalizes their Kustomizations with a shared `replacements` folder for doing common replacements down to HTTPRoute or Client resources.