### PR TITLE
fix(argocd): Fix resource tracking to support Velero snapshots

### DIFF
--- a/infrastructure/controllers/argocd/base/kustomization.yaml
+++ b/infrastructure/controllers/argocd/base/kustomization.yaml
@@ -38,6 +38,7 @@ helmCharts:
         controller.diff.server.side: true
         applicationsetcontroller.enable.progressive.syncs: true
       cm:
+        application.resourceTrackingMethod: annotation+label
         resource.ignoreResourceUpdatesEnabled: "true"
         resource.compareoptions: |
           ignoreResourceStatusField: all

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: dex-server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: repo-server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: server

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: application-controller

--- a/manifests/kind/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/kind/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   admin.enabled: "true"
   application.instanceLabelKey: argocd.argoproj.io/instance
+  application.resourceTrackingMethod: annotation+label
   application.sync.impersonation.enabled: "false"
   dex.config: |
     connectors:

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-dex-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: dex-server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-repo-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: repo-server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_deployment_argocd-server.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: server

--- a/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_apps_v1_statefulset_argocd-application-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/cm: f42b405434252b83577222b760be498fcd32fc10dbce8d81d4a2f70cde815afe
+        checksum/cm: 835ded4d42850f077f7fe9d51683b42f20dc8a5c01443f03675b641946040ed4
         checksum/cmd-params: 717f3b0799f95c4a67ec055f34ebdfdffe1cdbe99e5211588c581905c563de3b
       labels:
         app.kubernetes.io/component: application-controller

--- a/manifests/production/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/production/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   admin.enabled: "true"
   application.instanceLabelKey: argocd.argoproj.io/instance
+  application.resourceTrackingMethod: annotation+label
   application.sync.impersonation.enabled: "false"
   dex.config: |
     connectors:


### PR DESCRIPTION
Referencing https://github.com/vmware-tanzu/velero/issues/7905, switches resource tracking method to "annotation+label" to stop Argo CD from deleting VolumeSnapshots created by Velero.