### PR TITLE
fix(storage): Use device names in LINSTOR pool creation

### DIFF
--- a/infrastructure/configs/storage/production/pools.yaml
+++ b/infrastructure/configs/storage/production/pools.yaml
@@ -2,6 +2,8 @@ apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
   name: production-controlplane-1-pools
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   nodeSelector:
     kubernetes.io/hostname: production-controlplane-1
@@ -10,17 +12,19 @@ spec:
     lvmThinPool: {}
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09034
+      - /dev/sdb
   - name: hdd
     lvmThinPool: {}
     source:
       hostDevices:
-      - '/dev/disk/by-id/usb-WD_easystore_264D_3654475432533746-0:0'
+      - /dev/sda
 ---
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
   name: production-controlplane-2-pools
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   nodeSelector:
     kubernetes.io/hostname: production-controlplane-2
@@ -29,17 +33,19 @@ spec:
     lvmThinPool: {}
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09035
+      - /dev/sdb
   - name: hdd
     lvmThinPool: {}
     source:
       hostDevices:
-      - '/dev/disk/by-id/usb-WD_easystore_264D_3654483237453243-0:0'
+      - /dev/sda
 ---
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
   name: production-controlplane-3-pools
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   nodeSelector:
     kubernetes.io/hostname: production-controlplane-3
@@ -48,4 +54,4 @@ spec:
     lvmThinPool: {}
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09003
+      - /dev/sda

--- a/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-1-pools.yaml
+++ b/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-1-pools.yaml
@@ -1,6 +1,8 @@
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
   name: production-controlplane-1-pools
 spec:
   nodeSelector:
@@ -10,9 +12,9 @@ spec:
     name: ssd
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09034
+      - /dev/sdb
   - lvmThinPool: {}
     name: hdd
     source:
       hostDevices:
-      - /dev/disk/by-id/usb-WD_easystore_264D_3654475432533746-0:0
+      - /dev/sda

--- a/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-2-pools.yaml
+++ b/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-2-pools.yaml
@@ -1,6 +1,8 @@
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
   name: production-controlplane-2-pools
 spec:
   nodeSelector:
@@ -10,9 +12,9 @@ spec:
     name: ssd
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09035
+      - /dev/sdb
   - lvmThinPool: {}
     name: hdd
     source:
       hostDevices:
-      - /dev/disk/by-id/usb-WD_easystore_264D_3654483237453243-0:0
+      - /dev/sda

--- a/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-3-pools.yaml
+++ b/manifests/production/infrastructure/configs/storage/default_piraeus.io_v1_linstorsatelliteconfiguration_production-controlplane-3-pools.yaml
@@ -1,6 +1,8 @@
 apiVersion: piraeus.io/v1
 kind: LinstorSatelliteConfiguration
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
   name: production-controlplane-3-pools
 spec:
   nodeSelector:
@@ -10,4 +12,4 @@ spec:
     name: ssd
     source:
       hostDevices:
-      - /dev/disk/by-id/ata-SAMSUNG_MZ7KM1T9HMJP-00005_S3F6NX0KA09003
+      - /dev/sda


### PR DESCRIPTION
Go back to specifying disks in their storage pools as `/dev/sda`, `dev/sdb`, etc. Disks cannot be added to or removed from pools after creation.