### PR TITLE
fix(staging): Post staging deployment fixes

### DIFF
--- a/clusters/production/clusterconfig/patches/containerd-config.yaml
+++ b/clusters/production/clusterconfig/patches/containerd-config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://www.talos.dev/v1.7/schemas/config.schema.json
+machine:
+  files:
+  - op: create
+    path: /etc/cri/conf.d/20-customization.part
+    content: |
+      [plugins]
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true

--- a/clusters/production/clusterconfig/patches/disable-hostdns.yaml
+++ b/clusters/production/clusterconfig/patches/disable-hostdns.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://www.talos.dev/v1.7/schemas/config.schema.json
+machine:
+  features:
+    hostDNS:
+      enabled: false
+      forwardKubeDNSToHost: false

--- a/clusters/production/talconfig.yaml
+++ b/clusters/production/talconfig.yaml
@@ -79,5 +79,7 @@ controlPlane:
   - '@clusterconfig/patches/disk-encryption.yaml'
   - '@clusterconfig/patches/metrics-scraping.yaml'
   - '@clusterconfig/patches/disable-proxy.yaml'
+  - '@clusterconfig/patches/disable-hostdns.yaml'
+  - '@clusterconfig/patches/containerd-config.yaml'
   - '@clusterconfig/patches/oidc.yaml'
   - '@clusterconfig/patches/pod-security.yaml'

--- a/clusters/staging/clusterconfig/patches/containerd-config.yaml
+++ b/clusters/staging/clusterconfig/patches/containerd-config.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://www.talos.dev/v1.7/schemas/config.schema.json
+machine:
+  files:
+  - op: create
+    path: /etc/cri/conf.d/20-customization.part
+    content: |
+      [plugins]
+        [plugins."io.containerd.cri.v1.runtime"]
+          device_ownership_from_security_context = true

--- a/clusters/staging/clusterconfig/patches/disable-hostdns.yaml
+++ b/clusters/staging/clusterconfig/patches/disable-hostdns.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://www.talos.dev/v1.7/schemas/config.schema.json
+machine:
+  features:
+    hostDNS:
+      enabled: false
+      forwardKubeDNSToHost: false

--- a/clusters/staging/talconfig.yaml
+++ b/clusters/staging/talconfig.yaml
@@ -4,7 +4,7 @@ clusterName: staging
 talosVersion: v1.9.4
 # renovate: datasource=github-releases depName=kubernetes/kubernetes
 kubernetesVersion: v1.32.2
-endpoint: https://10.1.2.50:6443
+endpoint: https://10.1.2.51:6443
 nodes:
 - hostname: staging-controlplane-1
   ipAddress: 10.1.2.51
@@ -78,5 +78,7 @@ controlPlane:
   patches:
   - '@clusterconfig/patches/metrics-scraping.yaml'
   - '@clusterconfig/patches/disable-proxy.yaml'
+  - '@clusterconfig/patches/disable-hostdns.yaml'
+  - '@clusterconfig/patches/containerd-config.yaml'
   - '@clusterconfig/patches/oidc.yaml'
   - '@clusterconfig/patches/pod-security.yaml'

--- a/infrastructure/controllers/multus/base/kustomization.yaml
+++ b/infrastructure/controllers/multus/base/kustomization.yaml
@@ -11,3 +11,5 @@ images:
 
 patches:
 - path: patches/install-cni.yaml
+- path: patches/memory-limit-fix.yaml
+- path: patches/install-binary-fix.yaml

--- a/infrastructure/controllers/multus/base/patches/install-binary-fix.yaml
+++ b/infrastructure/controllers/multus/base/patches/install-binary-fix.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: install-multus-binary
+        command:
+        - "/usr/src/multus-cni/bin/install_multus"
+        - "-d"
+        - "/host/opt/cni/bin"
+        - "-t"
+        - "thick"

--- a/infrastructure/controllers/multus/base/patches/memory-limit-fix.yaml
+++ b/infrastructure/controllers/multus/base/patches/memory-limit-fix.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-multus
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi

--- a/infrastructure/controllers/multus/production/kustomization.yaml
+++ b/infrastructure/controllers/multus/production/kustomization.yaml
@@ -4,3 +4,6 @@ kind: Kustomization
 
 resources:
 - ../base
+
+patches:
+- path: patches/talos-host-run-netns.yaml

--- a/infrastructure/controllers/multus/production/patches/talos-host-run-netns.yaml
+++ b/infrastructure/controllers/multus/production/patches/talos-host-run-netns.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      volumes:
+      - name: host-run-netns
+        hostPath:
+          path: /var/run/netns/

--- a/manifests/kind/infrastructure/controllers/multus/apps_v1_daemonset_kube-multus-ds.yaml
+++ b/manifests/kind/infrastructure/controllers/multus/apps_v1_daemonset_kube-multus-ds.yaml
@@ -30,8 +30,8 @@ spec:
         name: kube-multus
         resources:
           limits:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 1000m
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -65,19 +65,11 @@ spec:
       hostPID: true
       initContainers:
       - command:
-        - /install-cni.sh
-        image: ghcr.io/siderolabs/install-cni:v1.9.0@sha256:53bdeb6c8d238dd593ee75f265baf4625925a034d8d18f10ffeae88d7fcf2c3e
-        name: install-cni
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          mountPropagation: Bidirectional
-          name: cnibin
-      - command:
-        - cp
-        - /usr/src/multus-cni/bin/multus-shim
-        - /host/opt/cni/bin/multus-shim
+        - /usr/src/multus-cni/bin/install_multus
+        - -d
+        - /host/opt/cni/bin
+        - -t
+        - thick
         image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
         name: install-multus-binary
         resources:
@@ -87,6 +79,16 @@ spec:
         securityContext:
           privileged: true
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          mountPropagation: Bidirectional
+          name: cnibin
+      - command:
+        - /install-cni.sh
+        image: ghcr.io/siderolabs/install-cni:v1.9.0@sha256:53bdeb6c8d238dd593ee75f265baf4625925a034d8d18f10ffeae88d7fcf2c3e
+        name: install-cni
+        securityContext:
+          privileged: true
         volumeMounts:
         - mountPath: /host/opt/cni/bin
           mountPropagation: Bidirectional

--- a/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-1.yaml
+++ b/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-1.yaml
@@ -28,7 +28,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         storageClassName: standard
   - metadata:
       name: hdd-staging-controlplane-1
@@ -40,7 +40,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 8T
+            storage: 2T
         storageClassName: standard
   instancetype:
     kind: VirtualMachineClusterInstanceType

--- a/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-2.yaml
+++ b/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-2.yaml
@@ -28,7 +28,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         storageClassName: standard
   - metadata:
       name: hdd-staging-controlplane-2
@@ -40,7 +40,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 8T
+            storage: 2T
         storageClassName: standard
   instancetype:
     kind: VirtualMachineClusterInstanceType

--- a/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-3.yaml
+++ b/manifests/kind/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-3.yaml
@@ -28,19 +28,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
-        storageClassName: standard
-  - metadata:
-      name: hdd-staging-controlplane-3
-    spec:
-      source:
-        blank: {}
-      storage:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8T
+            storage: 500G
         storageClassName: standard
   instancetype:
     kind: VirtualMachineClusterInstanceType
@@ -60,7 +48,6 @@ spec:
           disks:
           - name: rootfs
           - name: ssd
-          - name: hdd
           interfaces:
           - bridge: {}
             name: default
@@ -77,6 +64,3 @@ spec:
       - dataVolume:
           name: ssd-staging-controlplane-3
         name: ssd
-      - dataVolume:
-          name: hdd-staging-controlplane-3
-        name: hdd

--- a/manifests/production/infrastructure/controllers/multus/apps_v1_daemonset_kube-multus-ds.yaml
+++ b/manifests/production/infrastructure/controllers/multus/apps_v1_daemonset_kube-multus-ds.yaml
@@ -30,8 +30,8 @@ spec:
         name: kube-multus
         resources:
           limits:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 1000m
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -65,19 +65,11 @@ spec:
       hostPID: true
       initContainers:
       - command:
-        - /install-cni.sh
-        image: ghcr.io/siderolabs/install-cni:v1.9.0@sha256:53bdeb6c8d238dd593ee75f265baf4625925a034d8d18f10ffeae88d7fcf2c3e
-        name: install-cni
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /host/opt/cni/bin
-          mountPropagation: Bidirectional
-          name: cnibin
-      - command:
-        - cp
-        - /usr/src/multus-cni/bin/multus-shim
-        - /host/opt/cni/bin/multus-shim
+        - /usr/src/multus-cni/bin/install_multus
+        - -d
+        - /host/opt/cni/bin
+        - -t
+        - thick
         image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
         name: install-multus-binary
         resources:
@@ -91,6 +83,16 @@ spec:
         - mountPath: /host/opt/cni/bin
           mountPropagation: Bidirectional
           name: cnibin
+      - command:
+        - /install-cni.sh
+        image: ghcr.io/siderolabs/install-cni:v1.9.0@sha256:53bdeb6c8d238dd593ee75f265baf4625925a034d8d18f10ffeae88d7fcf2c3e
+        name: install-cni
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host/opt/cni/bin
+          mountPropagation: Bidirectional
+          name: cnibin
       serviceAccountName: multus
       terminationGracePeriodSeconds: 10
       tolerations:
@@ -99,6 +101,9 @@ spec:
       - effect: NoExecute
         operator: Exists
       volumes:
+      - hostPath:
+          path: /var/run/netns/
+        name: host-run-netns
       - hostPath:
           path: /etc/cni/net.d
         name: cni
@@ -126,8 +131,5 @@ spec:
       - hostPath:
           path: /run/k8s.cni.cncf.io
         name: host-run-k8s-cni-cncf-io
-      - hostPath:
-          path: /run/netns/
-        name: host-run-netns
   updateStrategy:
     type: RollingUpdate

--- a/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-1.yaml
+++ b/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-1.yaml
@@ -28,7 +28,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         storageClassName: ssd-r1
   - metadata:
       name: hdd-staging-controlplane-1
@@ -40,7 +40,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 8T
+            storage: 2T
         storageClassName: hdd-r1
   instancetype:
     kind: VirtualMachineClusterInstanceType

--- a/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-2.yaml
+++ b/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-2.yaml
@@ -28,7 +28,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         storageClassName: ssd-r1
   - metadata:
       name: hdd-staging-controlplane-2
@@ -40,7 +40,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 8T
+            storage: 2T
         storageClassName: hdd-r1
   instancetype:
     kind: VirtualMachineClusterInstanceType

--- a/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-3.yaml
+++ b/manifests/production/platform/staging/kubevirt.io_v1_virtualmachine_staging-controlplane-3.yaml
@@ -28,20 +28,8 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         storageClassName: ssd-r1
-  - metadata:
-      name: hdd-staging-controlplane-3
-    spec:
-      source:
-        blank: {}
-      storage:
-        accessModes:
-        - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8T
-        storageClassName: hdd-r1
   instancetype:
     kind: VirtualMachineClusterInstanceType
     name: o1.xlarge
@@ -60,7 +48,6 @@ spec:
           disks:
           - name: rootfs
           - name: ssd
-          - name: hdd
           interfaces:
           - bridge: {}
             name: default
@@ -79,6 +66,3 @@ spec:
       - dataVolume:
           name: ssd-staging-controlplane-3
         name: ssd
-      - dataVolume:
-          name: hdd-staging-controlplane-3
-        name: hdd

--- a/platform/staging/base/vms/staging-controlplane-3/patches/virtualmachine.yaml
+++ b/platform/staging/base/vms/staging-controlplane-3/patches/virtualmachine.yaml
@@ -9,3 +9,9 @@
   path: /spec/template/spec/nodeSelector
   value:
     kubernetes.io/hostname: production-controlplane-3
+- op: remove
+  path: /spec/dataVolumeTemplates/2
+- op: remove
+  path: /spec/template/spec/volumes/2
+- op: remove
+  path: /spec/template/spec/domain/devices/disks/2

--- a/platform/staging/base/vms/template/virtualmachine.yaml
+++ b/platform/staging/base/vms/template/virtualmachine.yaml
@@ -61,7 +61,7 @@ spec:
       storage:
         resources:
           requests:
-            storage: 2T
+            storage: 500G
         accessModes:
         - ReadWriteOnce
         storageClassName: ssd-r1
@@ -73,7 +73,7 @@ spec:
       storage:
         resources:
           requests:
-            storage: 8T
+            storage: 2T
         accessModes:
         - ReadWriteOnce
         storageClassName: hdd-r1

--- a/platform/staging/kind/kustomization.yaml
+++ b/platform/staging/kind/kustomization.yaml
@@ -10,3 +10,7 @@ patches:
 - path: patches/vms.yaml
   target:
     kind: VirtualMachine
+- path: patches/hdd.yaml
+  target:
+    kind: VirtualMachine
+    name: staging-controlplane-(1|2)

--- a/platform/staging/kind/patches/hdd.yaml
+++ b/platform/staging/kind/patches/hdd.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/json-patch
+- op: replace
+  path: /spec/dataVolumeTemplates/2/spec/storage/storageClassName
+  value: standard

--- a/platform/staging/kind/patches/vms.yaml
+++ b/platform/staging/kind/patches/vms.yaml
@@ -9,9 +9,6 @@
   path: /spec/dataVolumeTemplates/1/spec/storage/storageClassName
   value: standard
 - op: replace
-  path: /spec/dataVolumeTemplates/2/spec/storage/storageClassName
-  value: standard
-- op: replace
   path: /spec/instancetype/name
   value: o1.small
 - op: remove


### PR DESCRIPTION
Fixes problems introduced by KubeVirt and staging cluster implementation:
- Disable Host DNS functionality in Talos as it is unreachable with the current Cilium configuration
- Configures `device_ownership_from_security_context=true` to allow unprivileged pods access to block volumes
- Use a node's IP for the cluster endpoint as a VIP doesn't come up until after the cluster can start
- Workaround upstream bugs with Multus causing failures to start and pods being `OOMKilled` under the load associated with a full cluster restart
- Patch path of CNI run directory in Multus for compatibility with Talos Linux
- Reduce volume sizes requested by staging cluster to 1/4 of production as Linstor will not overprovision
- Remove HDD disk on node 3 to replicate production and to allow the VM to start on production node 3