### PR TITLE
fix(cloudflare-gateway): Use unique tunnel names for staging environment

### DIFF
--- a/apps/actual/staging/cloudflare-gateway.yaml
+++ b/apps/actual/staging/cloudflare-gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: actual-cloudflare
+  name: actual-cloudflare-staging
   namespace: actual
 spec:
   gatewayClassName: cloudflare

--- a/apps/actual/staging/patches/httproute.yaml
+++ b/apps/actual/staging/patches/httproute.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   parentRefs:
   - name: actual
-  - name: actual-cloudflare
+  - name: actual-cloudflare-staging

--- a/apps/ezxss/staging/gateway.yaml
+++ b/apps/ezxss/staging/gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: ezxss-cloudflare
+  name: ezxss-cloudflare-staging
   namespace: ezxss
 spec:
   gatewayClassName: cloudflare

--- a/apps/ezxss/staging/httproute.yaml
+++ b/apps/ezxss/staging/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ezxss
 spec:
   parentRefs:
-  - name: ezxss-cloudflare
+  - name: ezxss-cloudflare-staging
   hostnames:
   - staging.dm3.in
   rules:

--- a/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare-staging.yaml
+++ b/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare-staging.yaml
@@ -1,11 +1,12 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: ezxss-cloudflare
-  namespace: ezxss
+  name: actual-cloudflare-staging
+  namespace: actual
 spec:
   gatewayClassName: cloudflare
   listeners:
-  - name: http
+  - hostname: actual.staging.seigra.net
+    name: http
     port: 80
     protocol: HTTP

--- a/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
+++ b/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
@@ -12,7 +12,7 @@ spec:
   - actual.staging.seigra.net
   parentRefs:
   - name: actual
-  - name: actual-cloudflare
+  - name: actual-cloudflare-staging
   rules:
   - backendRefs:
     - name: actual-server

--- a/manifests/staging/apps/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss-cloudflare-staging.yaml
+++ b/manifests/staging/apps/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss-cloudflare-staging.yaml
@@ -1,12 +1,11 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: actual-cloudflare
-  namespace: actual
+  name: ezxss-cloudflare-staging
+  namespace: ezxss
 spec:
   gatewayClassName: cloudflare
   listeners:
-  - hostname: actual.staging.seigra.net
-    name: http
+  - name: http
     port: 80
     protocol: HTTP

--- a/manifests/staging/apps/ezxss/gateway.networking.k8s.io_v1_httproute_ezxss-cloudflare.yaml
+++ b/manifests/staging/apps/ezxss/gateway.networking.k8s.io_v1_httproute_ezxss-cloudflare.yaml
@@ -7,7 +7,7 @@ spec:
   hostnames:
   - staging.dm3.in
   parentRefs:
-  - name: ezxss-cloudflare
+  - name: ezxss-cloudflare-staging
   rules:
   - backendRefs:
     - name: ezxss

--- a/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak-cloudflare-staging.yaml
+++ b/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak-cloudflare-staging.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: keycloak-cloudflare
+  name: keycloak-cloudflare-staging
   namespace: keycloak
 spec:
   gatewayClassName: cloudflare

--- a/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak-cloudflare.yaml
+++ b/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak-cloudflare.yaml
@@ -7,7 +7,7 @@ spec:
   hostnames:
   - auth.staging.seigra.net
   parentRefs:
-  - name: keycloak-cloudflare
+  - name: keycloak-cloudflare-staging
   rules:
   - backendRefs:
     - name: keycloak

--- a/platform/idp/staging/cloudflare-gateway.yaml
+++ b/platform/idp/staging/cloudflare-gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: keycloak-cloudflare
+  name: keycloak-cloudflare-staging
   namespace: keycloak
 spec:
   gatewayClassName: cloudflare

--- a/platform/idp/staging/cloudflare-httproute.yaml
+++ b/platform/idp/staging/cloudflare-httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: keycloak
 spec:
   parentRefs:
-  - name: keycloak-cloudflare
+  - name: keycloak-cloudflare-staging
   hostnames:
   - auth.staging.seigra.net
   rules:


### PR DESCRIPTION
Fixes staging overwriting Cloudflare tunnels created in production.