### PR TITLE
fix(paperless-ngx): Workaround upstream runtime change

### DIFF
--- a/apps/paperless-ngx/base/kustomization.yaml
+++ b/apps/paperless-ngx/base/kustomization.yaml
@@ -18,7 +18,7 @@ images:
 - name: gotenberg/gotenberg
   newTag: 8.20.1@sha256:cda4386c7ed38f18bc6897828be01ba7361c99929a5c84ec5e293d7916e29bac
 - name: ghcr.io/paperless-ngx/paperless-ngx
-  newTag: 2.15.3@sha256:39b337e73c978238f0b529baf42f1b59b65d17eed35cd61bc1ccbbf779b5d58b
+  newTag: 2.14.7@sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab
 
 labels:
 - pairs:

--- a/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -69,7 +69,7 @@ spec:
             name: paperless-ngx-admin-password
         - secretRef:
             name: paperless-ngx-socialaccount-providers
-        image: ghcr.io/paperless-ngx/paperless-ngx:2.15.3@sha256:39b337e73c978238f0b529baf42f1b59b65d17eed35cd61bc1ccbbf779b5d58b
+        image: ghcr.io/paperless-ngx/paperless-ngx:2.14.7@sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab
         name: paperless-ngx
         ports:
         - containerPort: 8000

--- a/manifests/production/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/production/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -69,7 +69,7 @@ spec:
             name: paperless-ngx-admin-password
         - secretRef:
             name: paperless-ngx-socialaccount-providers
-        image: ghcr.io/paperless-ngx/paperless-ngx:2.15.3@sha256:39b337e73c978238f0b529baf42f1b59b65d17eed35cd61bc1ccbbf779b5d58b
+        image: ghcr.io/paperless-ngx/paperless-ngx:2.14.7@sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab
         name: paperless-ngx
         ports:
         - containerPort: 8000

--- a/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -69,7 +69,7 @@ spec:
             name: paperless-ngx-admin-password
         - secretRef:
             name: paperless-ngx-socialaccount-providers
-        image: ghcr.io/paperless-ngx/paperless-ngx:2.15.3@sha256:39b337e73c978238f0b529baf42f1b59b65d17eed35cd61bc1ccbbf779b5d58b
+        image: ghcr.io/paperless-ngx/paperless-ngx:2.14.7@sha256:2a6d9f6461ad7e8335f5b2123a173b9e6002fda209af8a66483b0c00629569ab
         name: paperless-ngx
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Works around upstream issue https://github.com/paperless-ngx/paperless-ngx/issues/9609 introduced by change to s6-overlay.