### PR TITLE
fix(keycloak): Increase memory limits

### DIFF
--- a/manifests/kind/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/kind/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -100,11 +100,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -166,11 +166,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -100,11 +100,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -166,11 +166,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifests/staging/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/staging/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -100,11 +100,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -166,11 +166,11 @@ spec:
           limits:
             cpu: 750m
             ephemeral-storage: 2Gi
-            memory: 768Mi
+            memory: 4Gi
           requests:
             cpu: 500m
             ephemeral-storage: 50Mi
-            memory: 512Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/platform/idp/base/kustomization.yaml
+++ b/platform/idp/base/kustomization.yaml
@@ -47,3 +47,12 @@ helmCharts:
       existingSecretUserKey: user
       existingSecretDatabaseKey: dbname
       existingSecretPasswordKey: password
+    resources:
+      requests:
+        cpu: 500m
+        memory: 3Gi
+        ephemeral-storage: 50Mi
+      limits:
+        cpu: 750m
+        memory: 4Gi
+        ephemeral-storage: 2Gi


### PR DESCRIPTION
Increases memory to Keycloak pod to prevent it from being `OOMKilled`.