### PR TITLE
fix(paperless): Mount /run in emptyDir for s6-overlay compat

### DIFF
--- a/apps/paperless-ngx/base/paperless-ngx/deployment.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - secretRef:
             name: paperless-ngx-socialaccount-providers
         env:
+        - name: S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES
+          value: "1"
         - name: PAPERLESS_DBHOST
           valueFrom:
             secretKeyRef:
@@ -56,6 +58,8 @@ spec:
               name: paperless-ngx-db-app
               key: password
         volumeMounts:
+        - name: run
+          mountPath: /run
         - name: data
           mountPath: /usr/src/paperless/data
         - name: media
@@ -73,6 +77,8 @@ spec:
           httpGet:
             port: 8000
       volumes:
+      - name: run
+        emptyDir: {}
       - name: data
         persistentVolumeClaim:
           claimName: paperless-ngx-data

--- a/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/kind/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -35,6 +35,8 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - env:
+        - name: S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES
+          value: "1"
         - name: PAPERLESS_DBHOST
           valueFrom:
             secretKeyRef:
@@ -85,6 +87,8 @@ spec:
           runAsGroup: 1000
           runAsUser: 1000
         volumeMounts:
+        - mountPath: /run
+          name: run
         - mountPath: /usr/src/paperless/data
           name: data
         - mountPath: /usr/src/paperless/media
@@ -99,6 +103,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+      - emptyDir: {}
+        name: run
       - name: data
         persistentVolumeClaim:
           claimName: paperless-ngx-data

--- a/manifests/production/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/production/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -35,6 +35,8 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - env:
+        - name: S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES
+          value: "1"
         - name: PAPERLESS_DBHOST
           valueFrom:
             secretKeyRef:
@@ -85,6 +87,8 @@ spec:
           runAsGroup: 1000
           runAsUser: 1000
         volumeMounts:
+        - mountPath: /run
+          name: run
         - mountPath: /usr/src/paperless/data
           name: data
         - mountPath: /usr/src/paperless/media
@@ -99,6 +103,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+      - emptyDir: {}
+        name: run
       - name: data
         persistentVolumeClaim:
           claimName: paperless-ngx-data

--- a/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -35,6 +35,8 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - env:
+        - name: S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES
+          value: "1"
         - name: PAPERLESS_DBHOST
           valueFrom:
             secretKeyRef:
@@ -85,6 +87,8 @@ spec:
           runAsGroup: 1000
           runAsUser: 1000
         volumeMounts:
+        - mountPath: /run
+          name: run
         - mountPath: /usr/src/paperless/data
           name: data
         - mountPath: /usr/src/paperless/media
@@ -99,6 +103,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       volumes:
+      - emptyDir: {}
+        name: run
       - name: data
         persistentVolumeClaim:
           claimName: paperless-ngx-data


### PR DESCRIPTION
After the upstream paperless-ngx container switched to using s6-overlay, starting failed without root privileges. Since [3.2.1.0](https://github.com/just-containers/s6-overlay/issues/600#issuecomment-2857621695), an environment variable can be set to allow mounting `/run` as an `emptyDir`.