### PR TITLE
fix(ezxss): Extend database storage

### DIFF
--- a/apps/ezxss/base/database.yaml
+++ b/apps/ezxss/base/database.yaml
@@ -10,7 +10,7 @@ spec:
   database: ezxss
   image: ghcr.io/mariadb/mariadb
   storage:
-    size: 1Gi
+    size: 10Gi
     storageClassName: ssd-r1
   metrics:
     enabled: true

--- a/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -36,6 +36,6 @@ spec:
       drop:
       - ALL
   storage:
-    size: 1Gi
+    size: 10Gi
     storageClassName: standard
   username: ezxss

--- a/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -36,6 +36,6 @@ spec:
       drop:
       - ALL
   storage:
-    size: 1Gi
+    size: 10Gi
     storageClassName: ssd-r1
   username: ezxss

--- a/manifests/staging/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/staging/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -36,6 +36,6 @@ spec:
       drop:
       - ALL
   storage:
-    size: 1Gi
+    size: 10Gi
     storageClassName: ssd-r1
   username: ezxss


### PR DESCRIPTION
Extends storage for the MariaDB database to 10Gi due to running out of storage in the volume.