### PR TITLE
fix(staging): Use single level domain for staging

### DIFF
--- a/apps/actual/staging/patches/configmap.yaml
+++ b/apps/actual/staging/patches/configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: actual-server-openid-config
   namespace: actual
 data:
-  issuer: https://auth.staging.seigra.net/realms/home
+  issuer: https://auth-staging.seigra.net/realms/home

--- a/apps/actual/staging/patches/gateway.yaml
+++ b/apps/actual/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: actual.staging.seigra.net
+  value: actual-staging.seigra.net

--- a/apps/paperless-ngx/staging/patches/gateway.yaml
+++ b/apps/paperless-ngx/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: paperless.staging.seigra.net
+  value: paperless-staging.seigra.net

--- a/apps/paperless-ngx/staging/patches/paperless-ngx-socialaccount-config.yaml
+++ b/apps/paperless-ngx/staging/patches/paperless-ngx-socialaccount-config.yaml
@@ -4,4 +4,4 @@ metadata:
   name: paperless-ngx-socialaccount-config
   namespace: paperless-ngx
 data:
-  server_url: https://auth.staging.seigra.net/realms/home/.well-known/openid-configuration
+  server_url: https://auth-staging.seigra.net/realms/home/.well-known/openid-configuration

--- a/clusters/staging/clusterconfig/patches/oidc.yaml
+++ b/clusters/staging/clusterconfig/patches/oidc.yaml
@@ -2,7 +2,7 @@
 cluster:
   apiServer:
     extraArgs:
-      oidc-issuer-url: https://auth.staging.seigra.net/realms/home
+      oidc-issuer-url: https://auth-staging.seigra.net/realms/home
       oidc-client-id: kubernetes
       oidc-username-claim: email
       oidc-groups-claim: groups

--- a/infrastructure/controllers/argocd/staging/patches/argocd-cm.yaml
+++ b/infrastructure/controllers/argocd/staging/patches/argocd-cm.yaml
@@ -4,14 +4,14 @@ metadata:
   name: argocd-cm
   namespace: argocd
 data:
-  url: https://argocd.staging.seigra.net
+  url: https://argocd-staging.seigra.net
   dex.config: |
     connectors:
     - type: oidc
       id: keycloak
       name: seigra.net
       config:
-        issuer: https://auth.staging.seigra.net/realms/home
+        issuer: https://auth-staging.seigra.net/realms/home
         clientID: argocd
         clientSecret: $argocd-oidc-secret:client_secret
         scopes:

--- a/infrastructure/controllers/argocd/staging/patches/gateway.yaml
+++ b/infrastructure/controllers/argocd/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: argocd.staging.seigra.net
+  value: argocd-staging.seigra.net

--- a/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare-staging.yaml
+++ b/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare-staging.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   gatewayClassName: cloudflare
   listeners:
-  - hostname: actual.staging.seigra.net
+  - hostname: actual-staging.seigra.net
     name: http
     port: 80
     protocol: HTTP

--- a/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
+++ b/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   gatewayClassName: envoy-gateway
   listeners:
-  - hostname: actual.staging.seigra.net
+  - hostname: actual-staging.seigra.net
     name: actual
     port: 443
     protocol: HTTPS

--- a/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
+++ b/manifests/staging/apps/actual/gateway.networking.k8s.io_v1_httproute_actual.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: actual
 spec:
   hostnames:
-  - actual.staging.seigra.net
+  - actual-staging.seigra.net
   parentRefs:
   - name: actual
   - name: actual-cloudflare-staging

--- a/manifests/staging/apps/actual/openidclient.keycloak.crossplane.io_v1alpha1_client_actual.yaml
+++ b/manifests/staging/apps/actual/openidclient.keycloak.crossplane.io_v1alpha1_client_actual.yaml
@@ -14,9 +14,9 @@ spec:
     clientId: actual
     realmIdRef:
       name: home
-    rootUrl: https://actual.staging.seigra.net
+    rootUrl: https://actual-staging.seigra.net
     standardFlowEnabled: true
     validRedirectUris:
-    - https://actual.staging.seigra.net/openid/callback
+    - https://actual-staging.seigra.net/openid/callback
   publishConnectionDetailsTo:
     name: keycloak-client-actual

--- a/manifests/staging/apps/actual/v1_configmap_actual-server-openid-config.yaml
+++ b/manifests/staging/apps/actual/v1_configmap_actual-server-openid-config.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 data:
   authMethod: oauth2
   client_id: actual
-  issuer: https://auth.staging.seigra.net/realms/home
-  server_hostname: https://actual.staging.seigra.net
+  issuer: https://auth-staging.seigra.net/realms/home
+  server_hostname: https://actual-staging.seigra.net
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/apps_v1_deployment_paperless-ngx.yaml
@@ -64,7 +64,7 @@ spec:
               name: paperless-ngx-db-app
         envFrom:
         - configMapRef:
-            name: paperless-ngx-config-mm6mm5k75g
+            name: paperless-ngx-config-g887cc9tth
         - secretRef:
             name: paperless-ngx-secret-key
         - secretRef:

--- a/manifests/staging/apps/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
@@ -16,7 +16,7 @@ spec:
   - allowedRoutes:
       namespaces:
         from: Same
-    hostname: paperless.staging.seigra.net
+    hostname: paperless-staging.seigra.net
     name: paperless-ngx
     port: 443
     protocol: HTTPS

--- a/manifests/staging/apps/paperless-ngx/gateway.networking.k8s.io_v1_httproute_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/gateway.networking.k8s.io_v1_httproute_paperless-ngx.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: paperless-ngx
 spec:
   hostnames:
-  - paperless.staging.seigra.net
+  - paperless-staging.seigra.net
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/manifests/staging/apps/paperless-ngx/openidclient.keycloak.crossplane.io_v1alpha1_client_paperless-ngx.yaml
+++ b/manifests/staging/apps/paperless-ngx/openidclient.keycloak.crossplane.io_v1alpha1_client_paperless-ngx.yaml
@@ -15,9 +15,9 @@ spec:
     clientId: paperless-ngx
     realmIdRef:
       name: home
-    rootUrl: https://paperless.staging.seigra.net
+    rootUrl: https://paperless-staging.seigra.net
     standardFlowEnabled: true
     validRedirectUris:
-    - https://paperless.staging.seigra.net/accounts/oidc/keycloak/login/callback/
+    - https://paperless-staging.seigra.net/accounts/oidc/keycloak/login/callback/
   publishConnectionDetailsTo:
     name: keycloak-client-paperless-ngx

--- a/manifests/staging/apps/paperless-ngx/v1_configmap_paperless-ngx-config-g887cc9tth.yaml
+++ b/manifests/staging/apps/paperless-ngx/v1_configmap_paperless-ngx-config-g887cc9tth.yaml
@@ -8,7 +8,7 @@ data:
   PAPERLESS_TIKA_ENABLED: "1"
   PAPERLESS_TIKA_ENDPOINT: http://paperless-ngx-tika:9998
   PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-ngx-gotenberg:3000
-  PAPERLESS_URL: https://paperless.staging.seigra.net
+  PAPERLESS_URL: https://paperless-staging.seigra.net
   REQUESTS_CA_BUNDLE: /bundle.pem
 kind: ConfigMap
 metadata:
@@ -17,5 +17,5 @@ metadata:
     app.kubernetes.io/instance: paperless-ngx
     app.kubernetes.io/name: paperless-ngx
     app.kubernetes.io/part-of: paperless-ngx
-  name: paperless-ngx-config-mm6mm5k75g
+  name: paperless-ngx-config-g887cc9tth
   namespace: paperless-ngx

--- a/manifests/staging/apps/paperless-ngx/v1_configmap_paperless-ngx-socialaccount-config.yaml
+++ b/manifests/staging/apps/paperless-ngx/v1_configmap_paperless-ngx-socialaccount-config.yaml
@@ -3,7 +3,7 @@ data:
   client_id: paperless-ngx
   name: seigra.net
   provider_id: keycloak
-  server_url: https://auth.staging.seigra.net/realms/home/.well-known/openid-configuration
+  server_url: https://auth-staging.seigra.net/realms/home/.well-known/openid-configuration
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/staging/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
+++ b/manifests/staging/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   gatewayClassName: envoy-gateway
   listeners:
-  - hostname: argocd.staging.seigra.net
+  - hostname: argocd-staging.seigra.net
     name: argocd
     port: 443
     protocol: HTTPS

--- a/manifests/staging/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_httproute_argocd-server.yaml
+++ b/manifests/staging/infrastructure/controllers/argocd/argocd_gateway.networking.k8s.io_v1_httproute_argocd-server.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: argocd
 spec:
   hostnames:
-  - argocd.staging.seigra.net
+  - argocd-staging.seigra.net
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/manifests/staging/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
+++ b/manifests/staging/infrastructure/controllers/argocd/argocd_v1_configmap_argocd-cm.yaml
@@ -10,7 +10,7 @@ data:
       id: keycloak
       name: seigra.net
       config:
-        issuer: https://auth.staging.seigra.net/realms/home
+        issuer: https://auth-staging.seigra.net/realms/home
         clientID: argocd
         clientSecret: $argocd-oidc-secret:client_secret
         scopes:
@@ -203,7 +203,7 @@ data:
   timeout.hard.reconciliation: 0s
   timeout.reconciliation: 180s
   timeout.reconciliation.jitter: 1m
-  url: https://argocd.staging.seigra.net
+  url: https://argocd-staging.seigra.net
 kind: ConfigMap
 metadata:
   labels:

--- a/manifests/staging/infrastructure/controllers/argocd/default_openidclient.keycloak.crossplane.io_v1alpha1_client_argocd.yaml
+++ b/manifests/staging/infrastructure/controllers/argocd/default_openidclient.keycloak.crossplane.io_v1alpha1_client_argocd.yaml
@@ -10,9 +10,9 @@ spec:
     fullScopeAllowed: false
     realmIdRef:
       name: home
-    rootUrl: https://argocd.staging.seigra.net
+    rootUrl: https://argocd-staging.seigra.net
     standardFlowEnabled: true
     validRedirectUris:
-    - https://argocd.staging.seigra.net/api/dex/callback
+    - https://argocd-staging.seigra.net/api/dex/callback
   publishConnectionDetailsTo:
     name: argocd-oidc-secret

--- a/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
+++ b/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   gatewayClassName: envoy-gateway
   listeners:
-  - hostname: auth.staging.seigra.net
+  - hostname: auth-staging.seigra.net
     name: keycloak
     port: 443
     protocol: HTTPS

--- a/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak-cloudflare.yaml
+++ b/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak-cloudflare.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: keycloak
 spec:
   hostnames:
-  - auth.staging.seigra.net
+  - auth-staging.seigra.net
   parentRefs:
   - name: keycloak-cloudflare-staging
   rules:

--- a/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak.yaml
+++ b/manifests/staging/platform/idp/keycloak_gateway.networking.k8s.io_v1_httproute_keycloak.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: keycloak
 spec:
   hostnames:
-  - auth.staging.seigra.net
+  - auth-staging.seigra.net
   parentRefs:
   - name: keycloak
   rules:

--- a/manifests/staging/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_securitypolicy_kubernetes-dashboard.yaml
+++ b/manifests/staging/platform/kubernetes-dashboard/gateway.envoyproxy.io_v1alpha1_securitypolicy_kubernetes-dashboard.yaml
@@ -13,15 +13,15 @@ spec:
       idToken: IdToken
     forwardAccessToken: true
     provider:
-      authorizationEndpoint: https://auth.staging.seigra.net/realms/home/protocol/openid-connect/auth
+      authorizationEndpoint: https://auth-staging.seigra.net/realms/home/protocol/openid-connect/auth
       backendSettings:
         retry:
           numRetries: 2
           retryOn:
             triggers:
             - reset
-      issuer: https://auth.staging.seigra.net/realms/home
-      tokenEndpoint: https://auth.staging.seigra.net/realms/home/protocol/openid-connect/token
+      issuer: https://auth-staging.seigra.net/realms/home
+      tokenEndpoint: https://auth-staging.seigra.net/realms/home/protocol/openid-connect/token
     refreshToken: true
   targetRefs:
   - group: gateway.networking.k8s.io

--- a/manifests/staging/platform/kubernetes-dashboard/gateway.networking.k8s.io_v1_gateway_kubernetes-dashboard.yaml
+++ b/manifests/staging/platform/kubernetes-dashboard/gateway.networking.k8s.io_v1_gateway_kubernetes-dashboard.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   gatewayClassName: envoy-gateway
   listeners:
-  - hostname: k8s.staging.seigra.net
+  - hostname: k8s-staging.seigra.net
     name: kubernetes-dashboard
     port: 443
     protocol: HTTPS

--- a/manifests/staging/platform/kubernetes-dashboard/gateway.networking.k8s.io_v1_httproute_kubernetes-dashboard.yaml
+++ b/manifests/staging/platform/kubernetes-dashboard/gateway.networking.k8s.io_v1_httproute_kubernetes-dashboard.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kubernetes-dashboard
 spec:
   hostnames:
-  - k8s.staging.seigra.net
+  - k8s-staging.seigra.net
   parentRefs:
   - name: kubernetes-dashboard
   rules:

--- a/manifests/staging/platform/kubernetes-dashboard/openidclient.keycloak.crossplane.io_v1alpha1_client_kubernetes-dashboard.yaml
+++ b/manifests/staging/platform/kubernetes-dashboard/openidclient.keycloak.crossplane.io_v1alpha1_client_kubernetes-dashboard.yaml
@@ -11,9 +11,9 @@ spec:
     fullScopeAllowed: false
     realmIdRef:
       name: home
-    rootUrl: https://k8s.staging.seigra.net
+    rootUrl: https://k8s-staging.seigra.net
     standardFlowEnabled: true
     validRedirectUris:
-    - https://k8s.staging.seigra.net/oauth2/callback
+    - https://k8s-staging.seigra.net/oauth2/callback
   publishConnectionDetailsTo:
     name: kubernetes-dashboard-oidc-secret

--- a/manifests/staging/platform/monitoring/default_openidclient.keycloak.crossplane.io_v1alpha1_client_grafana.yaml
+++ b/manifests/staging/platform/monitoring/default_openidclient.keycloak.crossplane.io_v1alpha1_client_grafana.yaml
@@ -10,9 +10,9 @@ spec:
     fullScopeAllowed: false
     realmIdRef:
       name: home
-    rootUrl: https://grafana.staging.seigra.net
+    rootUrl: https://grafana-staging.seigra.net
     standardFlowEnabled: true
     validRedirectUris:
-    - https://grafana.staging.seigra.net/login/generic_oauth
+    - https://grafana-staging.seigra.net/login/generic_oauth
   publishConnectionDetailsTo:
     name: grafana-oidc-secret

--- a/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -11,7 +11,7 @@ spec:
   - allowedRoutes:
       namespaces:
         from: Same
-    hostname: grafana.staging.seigra.net
+    hostname: grafana-staging.seigra.net
     name: grafana
     port: 443
     protocol: HTTPS

--- a/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_httproute_grafana.yaml
+++ b/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_httproute_grafana.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: monitoring
 spec:
   hostnames:
-  - grafana.staging.seigra.net
+  - grafana-staging.seigra.net
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway

--- a/manifests/staging/platform/monitoring/monitoring_v1_configmap_grafana.yaml
+++ b/manifests/staging/platform/monitoring/monitoring_v1_configmap_grafana.yaml
@@ -5,8 +5,8 @@ data:
     check_for_updates = true
     [auth.generic_oauth]
     allow_sign_up = true
-    api_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/userinfo
-    auth_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/auth
+    api_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/userinfo
+    auth_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/auth
     auto_login = true
     client_id = grafana
     email_attribute_path = email
@@ -18,7 +18,7 @@ data:
     role_attribute_strict = true
     scopes = openid email profile offline_access
     tls_skip_verify_insecure = true
-    token_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/token
+    token_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/token
     [grafana_net]
     url = https://grafana.net
     [log]
@@ -29,8 +29,8 @@ data:
     plugins = /var/lib/grafana/plugins
     provisioning = /etc/grafana/provisioning
     [server]
-    domain = grafana.staging.seigra.net
-    root_url = https://grafana.staging.seigra.net
+    domain = grafana-staging.seigra.net
+    root_url = https://grafana-staging.seigra.net
 kind: ConfigMap
 metadata:
   labels:

--- a/platform/idp/staging/cloudflare-httproute.yaml
+++ b/platform/idp/staging/cloudflare-httproute.yaml
@@ -8,7 +8,7 @@ spec:
   parentRefs:
   - name: keycloak-cloudflare-staging
   hostnames:
-  - auth.staging.seigra.net
+  - auth-staging.seigra.net
   rules:
   - backendRefs:
     - name: keycloak

--- a/platform/idp/staging/patches/gateway.yaml
+++ b/platform/idp/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: auth.staging.seigra.net
+  value: auth-staging.seigra.net

--- a/platform/kubernetes-dashboard/staging/patches/gateway.yaml
+++ b/platform/kubernetes-dashboard/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: k8s.staging.seigra.net
+  value: k8s-staging.seigra.net

--- a/platform/kubernetes-dashboard/staging/patches/securitypolicy.yaml
+++ b/platform/kubernetes-dashboard/staging/patches/securitypolicy.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/oidc/provider/authorizationEndpoint
-  value: https://auth.staging.seigra.net/realms/home/protocol/openid-connect/auth
+  value: https://auth-staging.seigra.net/realms/home/protocol/openid-connect/auth
 - op: replace
   path: /spec/oidc/provider/tokenEndpoint
-  value: https://auth.staging.seigra.net/realms/home/protocol/openid-connect/token
+  value: https://auth-staging.seigra.net/realms/home/protocol/openid-connect/token
 - op: replace
   path: /spec/oidc/provider/issuer
-  value: https://auth.staging.seigra.net/realms/home
+  value: https://auth-staging.seigra.net/realms/home

--- a/platform/monitoring/staging/patches/configmap.yaml
+++ b/platform/monitoring/staging/patches/configmap.yaml
@@ -9,8 +9,8 @@ data:
     check_for_updates = true
     [auth.generic_oauth]
     allow_sign_up = true
-    api_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/userinfo
-    auth_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/auth
+    api_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/userinfo
+    auth_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/auth
     auto_login = true
     client_id = grafana
     email_attribute_path = email
@@ -22,7 +22,7 @@ data:
     role_attribute_strict = true
     scopes = openid email profile offline_access
     tls_skip_verify_insecure = true
-    token_url = https://auth.staging.seigra.net/realms/home/protocol/openid-connect/token
+    token_url = https://auth-staging.seigra.net/realms/home/protocol/openid-connect/token
     [grafana_net]
     url = https://grafana.net
     [log]
@@ -33,5 +33,5 @@ data:
     plugins = /var/lib/grafana/plugins
     provisioning = /etc/grafana/provisioning
     [server]
-    domain = grafana.staging.seigra.net
-    root_url = https://grafana.staging.seigra.net
+    domain = grafana-staging.seigra.net
+    root_url = https://grafana-staging.seigra.net

--- a/platform/monitoring/staging/patches/gateway.yaml
+++ b/platform/monitoring/staging/patches/gateway.yaml
@@ -1,4 +1,4 @@
 # yaml-language-server: $schema=https://json.schemastore.org/json-patch
 - op: replace
   path: /spec/listeners/0/hostname
-  value: grafana.staging.seigra.net
+  value: grafana-staging.seigra.net


### PR DESCRIPTION
Use "-staging" hostnames instead of a subdomain to workaround limitation of Cloudflare Universal certificate only.