### PR TITLE
fix(cilium): Remove network and broadcast addresses from pools

### DIFF
--- a/infrastructure/configs/ipam/production/ciliumloadbalancerippool.yaml
+++ b/infrastructure/configs/ipam/production/ciliumloadbalancerippool.yaml
@@ -5,4 +5,5 @@ metadata:
   name: lb-pool
 spec:
   blocks:
-  - cidr: 10.1.3.0/24
+  - start: 10.1.3.1
+    stop: 10.1.3.254

--- a/infrastructure/configs/ipam/staging/ciliumloadbalancerippool.yaml
+++ b/infrastructure/configs/ipam/staging/ciliumloadbalancerippool.yaml
@@ -5,4 +5,5 @@ metadata:
   name: lb-pool
 spec:
   blocks:
-  - cidr: 10.1.4.0/24
+  - start: 10.1.5.1
+    stop: 10.1.5.254

--- a/manifests/production/infrastructure/configs/ipam/cilium.io_v2alpha1_ciliumloadbalancerippool_lb-pool.yaml
+++ b/manifests/production/infrastructure/configs/ipam/cilium.io_v2alpha1_ciliumloadbalancerippool_lb-pool.yaml
@@ -4,4 +4,5 @@ metadata:
   name: lb-pool
 spec:
   blocks:
-  - cidr: 10.1.3.0/24
+  - start: 10.1.3.1
+    stop: 10.1.3.254

--- a/manifests/staging/infrastructure/configs/ipam/cilium.io_v2alpha1_ciliumloadbalancerippool_lb-pool.yaml
+++ b/manifests/staging/infrastructure/configs/ipam/cilium.io_v2alpha1_ciliumloadbalancerippool_lb-pool.yaml
@@ -4,4 +4,5 @@ metadata:
   name: lb-pool
 spec:
   blocks:
-  - cidr: 10.1.4.0/24
+  - start: 10.1.5.1
+    stop: 10.1.5.254


### PR DESCRIPTION
Fixes weird behavior with BGP and the traditional "network" address.