### PR TITLE
feat(cilium): Use cilium Gateway API implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ functionality including networking and persistent storage to applications.
   [cert-manager](https://cert-manager.io/) controller
 - [`infrastructure/controllers/cilium`](infrastructure/controllers/cilium) -
   [Cilium](https://cilium.io/) Container Network Interface (CNI) plugin handling
-  all networking including access from outside the cluster using BGP.
+  all networking including access from outside the cluster via the Gateway API
+  and BGP.
 - [`infrastructure/controllers/cloudflare-gateway`](infrastructure/controllers/cloudflare-gateway) -
   [Cloudflare Gateway](https://github.com/pl4nty/cloudflare-kubernetes-gateway/tree/main)
   for Cloudflare tunnels via
@@ -43,7 +44,7 @@ functionality including networking and persistent storage to applications.
   component to implement volume snapshots.
 - [`infrastructure/controllers/envoy-gateway`](infrastructure/controllers/envoy-gateway) -
   [Envoy Gateway](https://gateway.envoyproxy.io/) for handling ingress
-  connections into the cluster via the Gateway API.
+  connections that require built-in OIDC into the cluster via the Gateway API.
 - [`infrastructure/controllers/external-dns`](infrastructure/controllers/external-dns) -
   [ExternalDNS](https://kubernetes-sigs.github.io/external-dns/latest/) for
   adding DNS records from Gateway API routes

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -114,7 +114,7 @@ tasks:
       vars: {APP: infrastructure/configs/crossplane-keycloak}
 
   infrastructure:configs:gatewayclasses:
-    deps: ['infrastructure:controllers:envoy-gateway']
+    deps: ['infrastructure:controllers:cilium', 'infrastructure:controllers:envoy-gateway']
     cmds:
     - task: deploy
       vars: {APP: infrastructure/configs/gatewayclasses}

--- a/infrastructure/controllers/cilium/base/kustomization.yaml
+++ b/infrastructure/controllers/cilium/base/kustomization.yaml
@@ -47,6 +47,9 @@ helmCharts:
       enabled: true
     l2announcements:
       enabled: true
+    gatewayAPI:
+      enabled: true
+      enableAlpn: true
     encryption:
       enabled: true
       type: wireguard

--- a/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch

--- a/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system

--- a/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium

--- a/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-operator
         app.kubernetes.io/part-of: cilium

--- a/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
@@ -44,7 +44,13 @@ data:
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
   enable-endpoint-routes: "true"
+  enable-envoy-config: "true"
   enable-experimental-lb: "false"
+  enable-gateway-api: "true"
+  enable-gateway-api-alpn: "true"
+  enable-gateway-api-app-protocol: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-secrets-sync: "true"
   enable-health-check-loadbalancer-ip: "false"
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
@@ -82,8 +88,14 @@ data:
   encrypt-node: "true"
   envoy-access-log-buffer-size: "4096"
   envoy-base-id: "0"
+  envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
   external-envoy-proxy: "true"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  gateway-api-secrets-namespace: cilium-secrets
+  gateway-api-service-externaltrafficpolicy: Cluster
+  gateway-api-xff-num-trusted-hops: "0"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
   hubble-disable-tls: "false"

--- a/manifests/dev-talos/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
+++ b/manifests/dev-talos/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
@@ -69,6 +69,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - cilium.io
   resources:
@@ -216,3 +220,36 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/kind/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/kind/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       metallb.universe.tf/loadBalancerIPs: 172.18.0.7

--- a/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch

--- a/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system

--- a/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/manifests/production/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-operator
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
@@ -44,7 +44,13 @@ data:
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
   enable-endpoint-routes: "true"
+  enable-envoy-config: "true"
   enable-experimental-lb: "false"
+  enable-gateway-api: "true"
+  enable-gateway-api-alpn: "true"
+  enable-gateway-api-app-protocol: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-secrets-sync: "true"
   enable-health-check-loadbalancer-ip: "false"
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
@@ -82,8 +88,14 @@ data:
   encrypt-node: "true"
   envoy-access-log-buffer-size: "4096"
   envoy-base-id: "0"
+  envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
   external-envoy-proxy: "true"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  gateway-api-secrets-namespace: cilium-secrets
+  gateway-api-service-externaltrafficpolicy: Cluster
+  gateway-api-xff-num-trusted-hops: "0"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
   hubble-disable-tls: "false"

--- a/manifests/production/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
+++ b/manifests/production/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
@@ -69,6 +69,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - cilium.io
   resources:
@@ -216,3 +220,36 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/production/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/production/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch

--- a/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system

--- a/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/manifests/staging/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/kube-system_apps_v1_daemonset_cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium

--- a/manifests/staging/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: 64fad2f3f8b666f322ad45db9b16374d35ef3cc46b73bb11cb340444379d4855
+        cilium.io/cilium-configmap-checksum: 08ead1a9b0b41b2664ecb4dfd81fbaed187590594f7940724dd68ec6b333c009
       labels:
         app.kubernetes.io/name: cilium-operator
         app.kubernetes.io/part-of: cilium

--- a/manifests/staging/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/kube-system_v1_configmap_cilium-config.yaml
@@ -44,7 +44,13 @@ data:
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
   enable-endpoint-routes: "true"
+  enable-envoy-config: "true"
   enable-experimental-lb: "false"
+  enable-gateway-api: "true"
+  enable-gateway-api-alpn: "true"
+  enable-gateway-api-app-protocol: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-secrets-sync: "true"
   enable-health-check-loadbalancer-ip: "false"
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
@@ -82,8 +88,14 @@ data:
   encrypt-node: "true"
   envoy-access-log-buffer-size: "4096"
   envoy-base-id: "0"
+  envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
   external-envoy-proxy: "true"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  gateway-api-secrets-namespace: cilium-secrets
+  gateway-api-service-externaltrafficpolicy: Cluster
+  gateway-api-xff-num-trusted-hops: "0"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
   hubble-disable-tls: "false"

--- a/manifests/staging/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
+++ b/manifests/staging/infrastructure/controllers/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
@@ -69,6 +69,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - cilium.io
   resources:
@@ -216,3 +220,36 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/staging/platform/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/platform/monitoring/base/gateway/gateway.yaml
+++ b/platform/monitoring/base/gateway/gateway.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:


### PR DESCRIPTION
Switches most gateways back to Cilium. The exception is kubernetes-dashboard which relies on the the SecurityPolicy feature in Envoy Gateway for inline OIDC.