### PR TITLE
fix(task): Fix `task --list-all` hanging

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,6 +37,7 @@ tasks:
     - renovate --platform=local
 
   build:
+    internal: true
     label: build {{.APP}} {{.ENV}}
     requires:
       vars: [APP, ENV]


### PR DESCRIPTION
Makes build task internal to prevent `task --list-all` from entering an infinite loop.