### PR TITLE
fix(ezxss): Fix Galera containers

### DIFF
--- a/apps/ezxss/base/database.yaml
+++ b/apps/ezxss/base/database.yaml
@@ -10,6 +10,26 @@ spec:
   replicas: 3
   galera:
     enabled: true
+    config:
+      volumeClaimTemplate:
+        storageClassName: ssd-r1
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+    initContainer:
+      image: ghcr.io/mariadb-operator/mariadb-operator
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+    agent:
+      image: ghcr.io/mariadb-operator/mariadb-operator
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
   username: ezxss
   database: ezxss
   image: ghcr.io/mariadb/mariadb

--- a/apps/ezxss/base/kustomization.yaml
+++ b/apps/ezxss/base/kustomization.yaml
@@ -15,7 +15,9 @@ images:
 - name: ghcr.io/gadgetmg/ezxss
   newTag: master@sha256:cbac41ee394292952974d0805becdf05900911b59862e9124e3adb90b5709100
 - name: ghcr.io/mariadb/mariadb
-  newTag: 11.8.2-ubi9@sha256:40354d6d7b6b3fef2a7b082362f30716ceb2ea9cf357e841f93a7690fda0f017
+  newTag: 11.4.7-noble@sha256:b356bbd2d8b20137724f7531b7b294588f3d831941f41f9ffa774ea071d253fe
+- name: ghcr.io/mariadb-operator/mariadb-operator
+  newTag: 0.38.1@sha256:64cede8bb930e4c9a899084583878e4fe883c3fc34456c7dac56886fc30ead38
 
 components:
 - ../../../shared/components/crd-configurations

--- a/infrastructure/controllers/mariadb-operator/base/kustomization.yaml
+++ b/infrastructure/controllers/mariadb-operator/base/kustomization.yaml
@@ -20,6 +20,8 @@ helmCharts:
   valuesInline:
     crds:
       enabled: true
+    image:
+      repository: ghcr.io/mariadb-operator/mariadb-operator
     metrics:
       enabled: true
       serviceMonitor:

--- a/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/kind/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: ezxss
 spec:
   database: ezxss
-  image: ghcr.io/mariadb/mariadb:11.8.2-ubi9@sha256:40354d6d7b6b3fef2a7b082362f30716ceb2ea9cf357e841f93a7690fda0f017
+  image: ghcr.io/mariadb/mariadb:11.4.7-noble@sha256:b356bbd2d8b20137724f7531b7b294588f3d831941f41f9ffa774ea071d253fe
   metrics:
     enabled: true
     exporter:

--- a/manifests/kind/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
+++ b/manifests/kind/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
@@ -38,7 +38,7 @@ spec:
         envFrom:
         - configMapRef:
             name: mariadb-operator-env
-        image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+        image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/kind/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
+++ b/manifests/kind/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   MARIADB_DEFAULT_VERSION: "11.4"
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_EXPORTER_MAXSCALE: docker-registry2.mariadb.com/mariadb/maxscale-prometheus-exporter-ubi:v0.0.1
   RELATED_IMAGE_MARIADB: docker-registry1.mariadb.com/library/mariadb:11.4.5

--- a/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/production/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -9,8 +9,30 @@ metadata:
 spec:
   database: ezxss
   galera:
+    agent:
+      image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1@sha256:64cede8bb930e4c9a899084583878e4fe883c3fc34456c7dac56886fc30ead38
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+    config:
+      volumeClaimTemplate:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+        storageClassName: ssd-r1
     enabled: true
-  image: ghcr.io/mariadb/mariadb:11.8.2-ubi9@sha256:40354d6d7b6b3fef2a7b082362f30716ceb2ea9cf357e841f93a7690fda0f017
+    initContainer:
+      image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1@sha256:64cede8bb930e4c9a899084583878e4fe883c3fc34456c7dac56886fc30ead38
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+  image: ghcr.io/mariadb/mariadb:11.4.7-noble@sha256:b356bbd2d8b20137724f7531b7b294588f3d831941f41f9ffa774ea071d253fe
   metrics:
     enabled: true
     exporter:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
@@ -38,7 +38,7 @@ spec:
         envFrom:
         - configMapRef:
             name: mariadb-operator-env
-        image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+        image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/production/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
+++ b/manifests/production/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   MARIADB_DEFAULT_VERSION: "11.4"
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_EXPORTER_MAXSCALE: docker-registry2.mariadb.com/mariadb/maxscale-prometheus-exporter-ubi:v0.0.1
   RELATED_IMAGE_MARIADB: docker-registry1.mariadb.com/library/mariadb:11.4.5

--- a/manifests/staging/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
+++ b/manifests/staging/apps/ezxss/k8s.mariadb.com_v1alpha1_mariadb_ezxss-db.yaml
@@ -9,8 +9,30 @@ metadata:
 spec:
   database: ezxss
   galera:
+    agent:
+      image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1@sha256:64cede8bb930e4c9a899084583878e4fe883c3fc34456c7dac56886fc30ead38
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+    config:
+      volumeClaimTemplate:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi
+        storageClassName: ssd-r1
     enabled: true
-  image: ghcr.io/mariadb/mariadb:11.8.2-ubi9@sha256:40354d6d7b6b3fef2a7b082362f30716ceb2ea9cf357e841f93a7690fda0f017
+    initContainer:
+      image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1@sha256:64cede8bb930e4c9a899084583878e4fe883c3fc34456c7dac56886fc30ead38
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+  image: ghcr.io/mariadb/mariadb:11.4.7-noble@sha256:b356bbd2d8b20137724f7531b7b294588f3d831941f41f9ffa774ea071d253fe
   metrics:
     enabled: true
     exporter:

--- a/manifests/staging/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
+++ b/manifests/staging/infrastructure/controllers/mariadb-operator/apps_v1_deployment_mariadb-operator.yaml
@@ -38,7 +38,7 @@ spec:
         envFrom:
         - configMapRef:
             name: mariadb-operator-env
-        image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+        image: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/staging/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
+++ b/manifests/staging/infrastructure/controllers/mariadb-operator/v1_configmap_mariadb-operator-env.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   MARIADB_DEFAULT_VERSION: "11.4"
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.38.1
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:0.38.1
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_EXPORTER_MAXSCALE: docker-registry2.mariadb.com/mariadb/maxscale-prometheus-exporter-ubi:v0.0.1
   RELATED_IMAGE_MARIADB: docker-registry1.mariadb.com/library/mariadb:11.4.5

--- a/shared/components/crd-configurations/configuration.yaml
+++ b/shared/components/crd-configurations/configuration.yaml
@@ -1,3 +1,7 @@
 images:
 - path: spec/image
   kind: MariaDB
+- path: spec/galera/initContainer/image
+  kind: MariaDB
+- path: spec/galera/agent/image
+  kind: MariaDB


### PR DESCRIPTION
- Switches to the Ubuntu-based `mariadb` container which supports Galera
- Defines `securityContext` for `init` and `agent` containers of Galera `StatefulSet`
- Switches `mariadb` image to use latest LTS track (11.4)
- Configures MariaDB operator to use image from ghcr.io registry for certain Renovate support