### PR TITLE
fix(keycloak): Use AWS mirror for Bitnami images

### DIFF
--- a/manifests/kind/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/kind/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -53,7 +53,7 @@ spec:
         envFrom:
         - configMapRef:
             name: keycloak-env-vars
-        image: docker.io/bitnami/keycloak:26.3.3-debian-12-r0
+        image: ecr.aws/bitnami/keycloak:26.3.3-debian-12-r0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -141,7 +141,7 @@ spec:
           info "Copy operation completed"
         command:
         - /bin/bash
-        image: docker.io/bitnami/keycloak:26.3.3-debian-12-r0
+        image: ecr.aws/bitnami/keycloak:26.3.3-debian-12-r0
         imagePullPolicy: IfNotPresent
         name: prepare-write-dirs
         resources:

--- a/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
+++ b/manifests/production/platform/idp/keycloak_apps_v1_statefulset_keycloak.yaml
@@ -53,7 +53,7 @@ spec:
         envFrom:
         - configMapRef:
             name: keycloak-env-vars
-        image: docker.io/bitnami/keycloak:26.3.3-debian-12-r0
+        image: ecr.aws/bitnami/keycloak:26.3.3-debian-12-r0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -141,7 +141,7 @@ spec:
           info "Copy operation completed"
         command:
         - /bin/bash
-        image: docker.io/bitnami/keycloak:26.3.3-debian-12-r0
+        image: ecr.aws/bitnami/keycloak:26.3.3-debian-12-r0
         imagePullPolicy: IfNotPresent
         name: prepare-write-dirs
         resources:

--- a/platform/idp/base/kustomization.yaml
+++ b/platform/idp/base/kustomization.yaml
@@ -17,6 +17,10 @@ resources:
 components:
 - ../../../shared/components/strip-helm-labels
 
+images:
+- name: docker.io/bitnami/keycloak
+  newName: ecr.aws/bitnami/keycloak
+
 helmCharts:
 - name: keycloak
   repo: oci://docker.io/bitnamicharts


### PR DESCRIPTION
Switches to the AWS mirror for Bitnami images which have not yet been pulled by Broadcom.