### PR TITLE
feat(cilium): Use Cilium's Gateway API implementation

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -83,7 +83,7 @@ tasks:
     cmds:
     - argocd app create {{.APP}} --dest-name in-cluster --repo /nonexistent --path / --validate=false --upsert
     # Handle intermittent disconnects from the argocd-server service with a loop
-    - for i in {1..3}; do argocd app sync {{.APP}} --local manifests/{{.ENV}}/{{.APP}} --server-side --apply-out-of-sync-only --retry-limit 3 --output tree && break; sleep 1; done
+    - for i in {1..3}; do argocd app sync {{.APP}} --local manifests/{{.ENV}}/{{.APP}} --server-side --apply-out-of-sync-only --prune --retry-limit 3 --output tree && break; sleep 1; done
 
   bootstrap:
     deps:
@@ -109,7 +109,7 @@ tasks:
     - kubectl apply --server-side -f manifests/{{.ENV}}/cilium/v1_namespace_cilium-secrets.yaml
     - kubectl apply --server-side -f manifests/{{.ENV}}/argocd/v1_namespace_argocd.yaml
     - for: sources
-      cmd: kubectl apply --server-side -f {{.ITEM}}
+      cmd: kubectl apply --server-side --force-conflicts -f {{.ITEM}}
     - kubectl wait --namespace argocd --for=condition=available --timeout=5m deployment/argocd-applicationset-controller
     - kubectl wait --namespace argocd --for=condition=available --timeout=5m deployment/argocd-notifications-controller
     - kubectl wait --namespace argocd --for=condition=available --timeout=5m deployment/argocd-redis

--- a/apps/actual/base/actual-server/gateway.yaml
+++ b/apps/actual/base/actual-server/gateway.yaml
@@ -5,8 +5,9 @@ metadata:
   name: actual
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: actual.seigra.net
     name: actual

--- a/apps/actual/production/cloudflare-gateway.yaml
+++ b/apps/actual/production/cloudflare-gateway.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: actual-cloudflare
   namespace: actual
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   gatewayClassName: cloudflare
   listeners:

--- a/apps/argocd/base/gateway/gateway.yaml
+++ b/apps/argocd/base/gateway/gateway.yaml
@@ -6,8 +6,9 @@ metadata:
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - name: argocd
     hostname: argocd.seigra.net

--- a/apps/cilium/base/kustomization.yaml
+++ b/apps/cilium/base/kustomization.yaml
@@ -16,6 +16,7 @@ helmCharts:
   version: 1.18.3
   apiVersions:
   - monitoring.coreos.com/v1
+  - gateway.networking.k8s.io/v1/GatewayClass
   valuesInline:
     cni:
       exclusive: false
@@ -45,6 +46,11 @@ helmCharts:
       enabled: true
     l2announcements:
       enabled: true
+    gatewayAPI:
+      enabled: true
+      enableProxyProtocol: false
+      enableAppProtocol: true
+      enableAlpn: true
     encryption:
       enabled: true
       type: wireguard
@@ -71,6 +77,8 @@ helmCharts:
         rollOutPods: true
         prometheus:
           enabled: true
+          serviceMonitor:
+            enabled: true
       ui:
         enabled: true
         rollOutPods: true
@@ -81,6 +89,12 @@ helmCharts:
       enabled: true
       serviceMonitor:
         enabled: true
+    envoy:
+      rollOutPods: true
+      prometheus:
+        enabled: true
+        serviceMonitor:
+          enabled: true
     operator:
       rollOutPods: true
       prometheus:

--- a/apps/ezxss/base/gateway.yaml
+++ b/apps/ezxss/base/gateway.yaml
@@ -5,8 +5,9 @@ metadata:
   name: ezxss
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: dm3.in
     name: ezxss

--- a/apps/ezxss/production/gateway-cloudflare.yaml
+++ b/apps/ezxss/production/gateway-cloudflare.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: ezxss-cloudflare
   namespace: ezxss
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   gatewayClassName: cloudflare
   listeners:

--- a/apps/idp/base/gateway.yaml
+++ b/apps/idp/base/gateway.yaml
@@ -5,8 +5,9 @@ metadata:
   name: keycloak
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - name: keycloak
     hostname: auth.seigra.net

--- a/apps/idp/production/cloudflare-gateway.yaml
+++ b/apps/idp/production/cloudflare-gateway.yaml
@@ -4,6 +4,8 @@ kind: Gateway
 metadata:
   name: keycloak-cloudflare
   namespace: keycloak
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   gatewayClassName: cloudflare
   listeners:

--- a/apps/ipam/test/ciliuml2announcementpolicy.yaml
+++ b/apps/ipam/test/ciliuml2announcementpolicy.yaml
@@ -4,9 +4,5 @@ kind: CiliumL2AnnouncementPolicy
 metadata:
   name: policy1
 spec:
-  nodeSelector:
-    matchExpressions:
-    - key: node-role.kubernetes.io/control-plane
-      operator: DoesNotExist
   externalIPs: true
   loadBalancerIPs: true

--- a/apps/monitoring/base/gateway/gateway.yaml
+++ b/apps/monitoring/base/gateway/gateway.yaml
@@ -1,12 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/apps/monitoring/base/gateway/httproute.yaml
+++ b/apps/monitoring/base/gateway/httproute.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:

--- a/apps/paperless-ngx/base/paperless-ngx/gateway.yaml
+++ b/apps/paperless-ngx/base/paperless-ngx/gateway.yaml
@@ -5,8 +5,9 @@ metadata:
   name: paperless-ngx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/clusters/test/Taskfile.yaml
+++ b/clusters/test/Taskfile.yaml
@@ -30,6 +30,7 @@ tasks:
         --config-patch @clusterconfig/patches/kernel-modules.yaml \
         --config-patch @clusterconfig/patches/parallel-image-pulls.yaml \
         --config-patch-control-plane @clusterconfig/patches/etcd-max-request-bytes.yaml \
+        --config-patch-control-plane @clusterconfig/patches/oidc.yaml \
         --skip-k8s-node-readiness-check \
         --disk-preallocate=false \
         --use-vip \

--- a/clusters/test/clusterconfig/patches/oidc.yaml
+++ b/clusters/test/clusterconfig/patches/oidc.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.11/website/content/v1.11/schemas/config.schema.json
+cluster:
+  apiServer:
+    extraArgs:
+      oidc-issuer-url: https://auth.10.5.0.54.nip.io/realms/home
+      oidc-client-id: kubernetes
+      oidc-username-claim: email
+      oidc-groups-claim: groups
+      oidc-ca-file: /var/local/oidc/ca.crt
+    extraVolumes:
+    - hostPath: /var/local/oidc
+      mountPath: /var/local/oidc
+      readonly: true
+machine:
+  files:
+  - path: /var/local/oidc/ca.crt
+    op: create
+    permissions: 0o644
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIC9jCCAd6gAwIBAgIQP4+SQLR122JhTuRugtZD3DANBgkqhkiG9w0BAQsFADAV
+      MRMwEQYDVQQDEwpjbHVzdGVyLWNhMB4XDTI1MDIwMzIyNDk1N1oXDTM1MDIwMTIy
+      NDk1N1owFTETMBEGA1UEAxMKY2x1c3Rlci1jYTCCASIwDQYJKoZIhvcNAQEBBQAD
+      ggEPADCCAQoCggEBAObf1ex0Uv586wdShBQHMVKHsTRZa9wmER64efRONfvpFXDL
+      3u24Xf1FOnpy4++iqHOtKwauw2K2g6pg/dnfhovBfmsD5a/m/rP3PWDSrcZNpoIX
+      O45cDFoa/WSQiiYZc8cWT2iQEnXXE8A+E0EjeiCG6HQICJ8H01uEJFZIrAzmjTTM
+      4E4AaKYoYbvo0BLwXhBxvk0+b6curZAPoTbh6l3WaRWPtsY5tB18gXxpPOC6tMoZ
+      U61e5RKqIhIf/LK9Nh3eC6gtNR8/ixCuPgtKTL2olwQybY89G2U4rgxW2E9SEkgQ
+      dpKth1DUvTViTqL6IPKY3xXdhVVG4eIs4Fl+xXcCAwEAAaNCMEAwDgYDVR0PAQH/
+      BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFJgWG8AiXb7uQLK4xKZl
+      enGCVAJrMA0GCSqGSIb3DQEBCwUAA4IBAQAeuWV4IGI+5goY/rfFI6B05uhgtOm4
+      +JE5VmJLyLYT0sK65DpVEQuSKM/+nFaoVP9h06FgjW6cqWxrUIfDYZZtZySyMxAj
+      FiERhIAdETLonTcMzbS2h2DWLQKCg94aCLJhZSbWiWNDrOVpe0NZ7yrpG3hwKc5w
+      jH97TUCA+tPwNsQHAp5NGFdecTbvLAIig1MnPtZQhQHAO63U+NfnIH8J+C8DqcsT
+      eSumd3aIEsxeresDpsPw629MJj7462VxsPVX9dPdTOwUBx0jd+UJhx4LSPi7sur+
+      cUjOaFkPk5DZl3pWp93sGQWjXDF7++R+7jJg47APTkwaiCudFL+74q0j
+      -----END CERTIFICATE-----

--- a/manifests/production/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare.yaml
+++ b/manifests/production/actual/gateway.networking.k8s.io_v1_gateway_actual-cloudflare.yaml
@@ -1,6 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: actual-cloudflare
   namespace: actual
 spec:

--- a/manifests/production/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
+++ b/manifests/production/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   labels:
     app.kubernetes.io/component: application
@@ -10,7 +11,7 @@ metadata:
   name: actual
   namespace: actual
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: actual.seigra.net
     name: actual

--- a/manifests/production/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
+++ b/manifests/production/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   name: argocd
   namespace: argocd
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: argocd.seigra.net
     name: argocd

--- a/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
+++ b/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
+++ b/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch

--- a/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
+++ b/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system

--- a/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
+++ b/manifests/production/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/manifests/production/cilium/default_gateway.networking.k8s.io_v1_gatewayclass_cilium.yaml
+++ b/manifests/production/cilium/default_gateway.networking.k8s.io_v1_gatewayclass_cilium.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: cilium
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: The default Cilium GatewayClass

--- a/manifests/production/cilium/kube-system_apps_v1_daemonset_cilium-envoy.yaml
+++ b/manifests/production/cilium/kube-system_apps_v1_daemonset_cilium-envoy.yaml
@@ -14,6 +14,8 @@ spec:
       k8s-app: cilium-envoy
   template:
     metadata:
+      annotations:
+        cilium.io/cilium-envoy-configmap-checksum: efcd5d18b624444a6d334fcca1aef9c69f9b85247bfdb78c0f7c5bdf9c8e8a92
       labels:
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/cilium/kube-system_apps_v1_daemonset_cilium.yaml
+++ b/manifests/production/cilium/kube-system_apps_v1_daemonset_cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: ab31fad698ae8a8aef804eacca15971a195a9f476f73907d0b79ed19ecf2cf7a
+        cilium.io/cilium-configmap-checksum: 0a7ce29806bbd6133676a7c0647247cad245b4b33d9367983c626f113fa1f0bf
         kubectl.kubernetes.io/default-container: cilium-agent
       labels:
         app.kubernetes.io/name: cilium-agent

--- a/manifests/production/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/production/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: ab31fad698ae8a8aef804eacca15971a195a9f476f73907d0b79ed19ecf2cf7a
+        cilium.io/cilium-configmap-checksum: 0a7ce29806bbd6133676a7c0647247cad245b4b33d9367983c626f113fa1f0bf
       labels:
         app.kubernetes.io/name: cilium-operator
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/cilium/kube-system_apps_v1_deployment_hubble-relay.yaml
+++ b/manifests/production/cilium/kube-system_apps_v1_deployment_hubble-relay.yaml
@@ -20,8 +20,6 @@ spec:
     metadata:
       annotations:
         cilium.io/hubble-relay-configmap-checksum: da07254ba8b05a70e1fd8a27fbe5298b360205947f3bf3c53f58cfc7cc74159e
-        prometheus.io/port: "9966"
-        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: hubble-relay
         app.kubernetes.io/part-of: cilium

--- a/manifests/production/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_cilium-envoy.yaml
+++ b/manifests/production/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_cilium-envoy.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+  name: cilium-envoy
+  namespace: kube-system
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    path: /metrics
+    port: envoy-metrics
+    relabelings:
+    - action: replace
+      replacement: ${1}
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: cilium-envoy
+  targetLabels:
+  - k8s-app

--- a/manifests/production/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_hubble-relay.yaml
+++ b/manifests/production/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_hubble-relay.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  endpoints:
+  - interval: 10s
+    path: /metrics
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay

--- a/manifests/production/cilium/kube-system_v1_configmap_cilium-config.yaml
+++ b/manifests/production/cilium/kube-system_v1_configmap_cilium-config.yaml
@@ -45,6 +45,12 @@ data:
   enable-bpf-masquerade: "true"
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
+  enable-envoy-config: "true"
+  enable-gateway-api: "true"
+  enable-gateway-api-alpn: "true"
+  enable-gateway-api-app-protocol: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-secrets-sync: "true"
   enable-health-check-loadbalancer-ip: "false"
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
@@ -79,8 +85,14 @@ data:
   encrypt-node: "true"
   envoy-access-log-buffer-size: "4096"
   envoy-base-id: "0"
+  envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
   external-envoy-proxy: "true"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  gateway-api-secrets-namespace: cilium-secrets
+  gateway-api-service-externaltrafficpolicy: Cluster
+  gateway-api-xff-num-trusted-hops: "0"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
   hubble-disable-tls: "false"

--- a/manifests/production/cilium/kube-system_v1_service_cilium-envoy.yaml
+++ b/manifests/production/cilium/kube-system_v1_service_cilium-envoy.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9964"
-    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/name: cilium-envoy
     app.kubernetes.io/part-of: cilium

--- a/manifests/production/cilium/kube-system_v1_service_hubble-relay.yaml
+++ b/manifests/production/cilium/kube-system_v1_service_hubble-relay.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9966"
-    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium

--- a/manifests/production/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
+++ b/manifests/production/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
@@ -69,6 +69,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - cilium.io
   resources:
@@ -216,3 +220,57 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/production/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss-cloudflare.yaml
+++ b/manifests/production/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss-cloudflare.yaml
@@ -1,6 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: ezxss-cloudflare
   namespace: ezxss
 spec:

--- a/manifests/production/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss.yaml
+++ b/manifests/production/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   name: ezxss
   namespace: ezxss
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: dm3.in
     name: ezxss

--- a/manifests/production/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak-cloudflare.yaml
+++ b/manifests/production/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak-cloudflare.yaml
@@ -1,6 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
   name: keycloak-cloudflare
   namespace: keycloak
 spec:

--- a/manifests/production/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
+++ b/manifests/production/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   name: keycloak
   namespace: keycloak
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - hostname: auth.seigra.net
     name: keycloak

--- a/manifests/production/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/production/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/manifests/production/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
+++ b/manifests/production/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: letsencrypt
   labels:
     app.kubernetes.io/component: paperless-ngx
@@ -11,7 +12,7 @@ metadata:
   name: paperless-ngx
   namespace: paperless-ngx
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   listeners:
   - allowedRoutes:
       namespaces:

--- a/manifests/test/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
+++ b/manifests/test/actual/gateway.networking.k8s.io_v1_gateway_actual.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   labels:
     app.kubernetes.io/component: application
@@ -10,7 +11,7 @@ metadata:
   name: actual
   namespace: actual
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.59

--- a/manifests/test/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
+++ b/manifests/test/argocd/argocd_gateway.networking.k8s.io_v1_gateway_argocd.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   name: argocd
   namespace: argocd
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.53

--- a/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
+++ b/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-gateway-secrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
+++ b/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_role_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - update
+  - patch

--- a/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
+++ b/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system

--- a/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
+++ b/manifests/test/cilium/cilium-secrets_rbac.authorization.k8s.io_v1_rolebinding_cilium-operator-gateway-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/part-of: cilium
+  name: cilium-operator-gateway-secrets
+  namespace: cilium-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cilium-operator-gateway-secrets
+subjects:
+- kind: ServiceAccount
+  name: cilium-operator
+  namespace: kube-system

--- a/manifests/test/cilium/default_gateway.networking.k8s.io_v1_gatewayclass_cilium.yaml
+++ b/manifests/test/cilium/default_gateway.networking.k8s.io_v1_gatewayclass_cilium.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: cilium
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: The default Cilium GatewayClass

--- a/manifests/test/cilium/kube-system_apps_v1_daemonset_cilium-envoy.yaml
+++ b/manifests/test/cilium/kube-system_apps_v1_daemonset_cilium-envoy.yaml
@@ -14,6 +14,8 @@ spec:
       k8s-app: cilium-envoy
   template:
     metadata:
+      annotations:
+        cilium.io/cilium-envoy-configmap-checksum: efcd5d18b624444a6d334fcca1aef9c69f9b85247bfdb78c0f7c5bdf9c8e8a92
       labels:
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium

--- a/manifests/test/cilium/kube-system_apps_v1_daemonset_cilium.yaml
+++ b/manifests/test/cilium/kube-system_apps_v1_daemonset_cilium.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: ab31fad698ae8a8aef804eacca15971a195a9f476f73907d0b79ed19ecf2cf7a
+        cilium.io/cilium-configmap-checksum: 0a7ce29806bbd6133676a7c0647247cad245b4b33d9367983c626f113fa1f0bf
         kubectl.kubernetes.io/default-container: cilium-agent
       labels:
         app.kubernetes.io/name: cilium-agent

--- a/manifests/test/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
+++ b/manifests/test/cilium/kube-system_apps_v1_deployment_cilium-operator.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        cilium.io/cilium-configmap-checksum: ab31fad698ae8a8aef804eacca15971a195a9f476f73907d0b79ed19ecf2cf7a
+        cilium.io/cilium-configmap-checksum: 0a7ce29806bbd6133676a7c0647247cad245b4b33d9367983c626f113fa1f0bf
       labels:
         app.kubernetes.io/name: cilium-operator
         app.kubernetes.io/part-of: cilium

--- a/manifests/test/cilium/kube-system_apps_v1_deployment_hubble-relay.yaml
+++ b/manifests/test/cilium/kube-system_apps_v1_deployment_hubble-relay.yaml
@@ -20,8 +20,6 @@ spec:
     metadata:
       annotations:
         cilium.io/hubble-relay-configmap-checksum: da07254ba8b05a70e1fd8a27fbe5298b360205947f3bf3c53f58cfc7cc74159e
-        prometheus.io/port: "9966"
-        prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: hubble-relay
         app.kubernetes.io/part-of: cilium

--- a/manifests/test/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_cilium-envoy.yaml
+++ b/manifests/test/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_cilium-envoy.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: cilium-envoy
+    app.kubernetes.io/part-of: cilium
+  name: cilium-envoy
+  namespace: kube-system
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    path: /metrics
+    port: envoy-metrics
+    relabelings:
+    - action: replace
+      replacement: ${1}
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: cilium-envoy
+  targetLabels:
+  - k8s-app

--- a/manifests/test/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_hubble-relay.yaml
+++ b/manifests/test/cilium/kube-system_monitoring.coreos.com_v1_servicemonitor_hubble-relay.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: hubble-relay
+    app.kubernetes.io/part-of: cilium
+  name: hubble-relay
+  namespace: kube-system
+spec:
+  endpoints:
+  - interval: 10s
+    path: /metrics
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: hubble-relay

--- a/manifests/test/cilium/kube-system_v1_configmap_cilium-config.yaml
+++ b/manifests/test/cilium/kube-system_v1_configmap_cilium-config.yaml
@@ -45,6 +45,12 @@ data:
   enable-bpf-masquerade: "true"
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
+  enable-envoy-config: "true"
+  enable-gateway-api: "true"
+  enable-gateway-api-alpn: "true"
+  enable-gateway-api-app-protocol: "true"
+  enable-gateway-api-proxy-protocol: "false"
+  enable-gateway-api-secrets-sync: "true"
   enable-health-check-loadbalancer-ip: "false"
   enable-health-check-nodeport: "true"
   enable-health-checking: "true"
@@ -79,8 +85,14 @@ data:
   encrypt-node: "true"
   envoy-access-log-buffer-size: "4096"
   envoy-base-id: "0"
+  envoy-config-retry-interval: 15s
   envoy-keep-cap-netbindservice: "false"
   external-envoy-proxy: "true"
+  gateway-api-hostnetwork-enabled: "false"
+  gateway-api-hostnetwork-nodelabelselector: ""
+  gateway-api-secrets-namespace: cilium-secrets
+  gateway-api-service-externaltrafficpolicy: Cluster
+  gateway-api-xff-num-trusted-hops: "0"
   health-check-icmp-failure-threshold: "3"
   http-retry-count: "3"
   hubble-disable-tls: "false"

--- a/manifests/test/cilium/kube-system_v1_service_cilium-envoy.yaml
+++ b/manifests/test/cilium/kube-system_v1_service_cilium-envoy.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9964"
-    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/name: cilium-envoy
     app.kubernetes.io/part-of: cilium

--- a/manifests/test/cilium/kube-system_v1_service_hubble-relay.yaml
+++ b/manifests/test/cilium/kube-system_v1_service_hubble-relay.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/port: "9966"
-    prometheus.io/scrape: "true"
   labels:
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium

--- a/manifests/test/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
+++ b/manifests/test/cilium/rbac.authorization.k8s.io_v1_clusterrole_cilium-operator.yaml
@@ -69,6 +69,10 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - delete
+  - patch
 - apiGroups:
   - cilium.io
   resources:
@@ -216,3 +220,57 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - gateways
+  - tlsroutes
+  - httproutes
+  - grpcroutes
+  - referencegrants
+  - referencepolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - httproutes/status
+  - grpcroutes/status
+  - tlsroutes/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumgatewayclassconfigs/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/test/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss.yaml
+++ b/manifests/test/ezxss/gateway.networking.k8s.io_v1_gateway_ezxss.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   name: ezxss
   namespace: ezxss
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.52

--- a/manifests/test/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
+++ b/manifests/test/idp/keycloak_gateway.networking.k8s.io_v1_gateway_keycloak.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   name: keycloak
   namespace: keycloak
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.54

--- a/manifests/test/ipam/cilium.io_v2alpha1_ciliuml2announcementpolicy_policy1.yaml
+++ b/manifests/test/ipam/cilium.io_v2alpha1_ciliuml2announcementpolicy_policy1.yaml
@@ -5,7 +5,3 @@ metadata:
 spec:
   externalIPs: true
   loadBalancerIPs: true
-  nodeSelector:
-    matchExpressions:
-    - key: node-role.kubernetes.io/control-plane
-      operator: DoesNotExist

--- a/manifests/test/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
+++ b/manifests/test/monitoring/monitoring_gateway.networking.k8s.io_v1beta1_gateway_kube-prometheus.yaml
@@ -2,11 +2,12 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   name: kube-prometheus
   namespace: monitoring
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.57

--- a/manifests/test/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
+++ b/manifests/test/paperless-ngx/gateway.networking.k8s.io_v1_gateway_paperless-ngx.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
     cert-manager.io/cluster-issuer: cluster-ca
   labels:
     app.kubernetes.io/component: paperless-ngx
@@ -11,7 +12,7 @@ metadata:
   name: paperless-ngx
   namespace: paperless-ngx
 spec:
-  gatewayClassName: envoy-gateway
+  gatewayClassName: cilium
   infrastructure:
     annotations:
       lbipam.cilium.io/ips: 10.5.0.58


### PR DESCRIPTION
This adds Cilium's Gateway API implementation and switches `Gateway` resources to use it.

For now, Envoy Gateway is retained to support OIDC for the Kubernetes Dashboard. Support for this in the upstream Gateway API spec is planned to be supported by Cilium.