### PR TITLE
fix(build): Fix for namespace behavior changes in Kustomize v5.8.0

### DIFF
--- a/apps/idp/base/kustomization.yaml
+++ b/apps/idp/base/kustomization.yaml
@@ -39,7 +39,7 @@ helmCharts:
       enabled: true
       serviceMonitor:
         enabled: true
-        namespace: monitoring
+        namespace: keycloak
       prometheusRule:
         enabled: true
         namespace: monitoring

--- a/apps/mariadb-operator/base/kustomization.yaml
+++ b/apps/mariadb-operator/base/kustomization.yaml
@@ -10,11 +10,18 @@ resources:
 components:
 - ../../../shared/components/strip-helm-labels
 
+patches:
+- patch: |
+    - op: add
+      path: /metadata/namespace
+      value: mariadb-system
+  target:
+    kind: (ValidatingWebHookConfiguration|Deployment|ServiceMonitor|RoleBinding|Role|ConfigMap|ServiceAccount|Service)
+
 helmCharts:
 - name: mariadb-operator
   repo: https://mariadb-operator.github.io/mariadb-operator
   releaseName: mariadb-operator
-  namespace: mariadb-system
   version: 25.10.2
   includeCRDs: true
   valuesInline:


### PR DESCRIPTION
Kustomize v5.8.0 changed the behavior of the `namespace` field, specifically with relation to Helm. This fixes the sources to generate the same manifests.

Possibly related: https://github.com/kubernetes-sigs/kustomize/issues/6014