### PR TITLE
fix(redis-operator): Use alternative redis-operator image

### DIFF
--- a/apps/harbor/base/redis/redisfailover.yaml
+++ b/apps/harbor/base/redis/redisfailover.yaml
@@ -5,6 +5,7 @@ metadata:
   name: harbor
   labels:
     app.kubernetes.io/name: redis
+    redis-failover.freshworks.com/operator-group: redis-operator
 spec:
   redis:
     replicas: 3

--- a/apps/redis-operator/base/kustomization.yaml
+++ b/apps/redis-operator/base/kustomization.yaml
@@ -6,12 +6,20 @@ namespace: redis-operator
 
 resources:
 - namespace.yaml
-- https://github.com/freshworks/redis-operator/manifests/kustomize/overlays/full?ref=v3.3.2
+- https://github.com/freshworks/redis-operator/manifests/kustomize/overlays/full?ref=v3.3.3
 
 components:
 - ../../../shared/components/restricted-pod-security
 
 images:
-- name: quay.io/spotahome/redis-operator
-  newName: ghcr.io/freshworks/redis-operator
-  newTag: v3.3.2@sha256:1ea859add694dc9da5800e8fbcb05e300ebdf3d49ced6815d53d019380d20973
+- name: ghcr.io/freshworks/redis-operator
+  newName: ghcr.io/gadgetmg/redis-operator
+  newTag: 3.3.3@sha256:e59a02576e4752e5779baec85188d53ac77c6f55391fb9e0bfd227cea54878b6
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: 3.3.3
+
+patches:
+- path: patches/operator-group-id.yaml

--- a/apps/redis-operator/base/patches/operator-group-id.yaml
+++ b/apps/redis-operator/base/patches/operator-group-id.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.35.0/deployment.json
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-operator
+  namespace: redis-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: redis-operator
+        env:
+        - name: OPERATOR_GROUP_ID
+          value: redis-operator

--- a/crds/production/apiextensions.k8s.io_v1_customresourcedefinition_redisfailovers.databases.spotahome.com.yaml
+++ b/crds/production/apiextensions.k8s.io_v1_customresourcedefinition_redisfailovers.databases.spotahome.com.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redisfailovers.databases.spotahome.com
 spec:
   group: databases.spotahome.com
@@ -1674,6 +1674,11 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  disableMasterRollout:
+                    default: false
+                    description: When true, only slave pods are rolled out on spec
+                      change (OnDelete); master is not deleted until this is false.
+                    type: boolean
                   disablePodDisruptionBudget:
                     type: boolean
                   dnsPolicy:

--- a/crds/test/apiextensions.k8s.io_v1_customresourcedefinition_redisfailovers.databases.spotahome.com.yaml
+++ b/crds/test/apiextensions.k8s.io_v1_customresourcedefinition_redisfailovers.databases.spotahome.com.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redisfailovers.databases.spotahome.com
 spec:
   group: databases.spotahome.com
@@ -1674,6 +1674,11 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  disableMasterRollout:
+                    default: false
+                    description: When true, only slave pods are rolled out on spec
+                      change (OnDelete); master is not deleted until this is false.
+                    type: boolean
                   disablePodDisruptionBudget:
                     type: boolean
                   dnsPolicy:

--- a/manifests/production/harbor/databases.spotahome.com_v1_redisfailover_harbor.yaml
+++ b/manifests/production/harbor/databases.spotahome.com_v1_redisfailover_harbor.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/instance: harbor
     app.kubernetes.io/name: redis
     app.kubernetes.io/part-of: harbor
+    redis-failover.freshworks.com/operator-group: redis-operator
   name: harbor
   namespace: harbor
 spec:

--- a/manifests/production/redis-operator/apps_v1_deployment_redis-operator.yaml
+++ b/manifests/production/redis-operator/apps_v1_deployment_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:
@@ -22,7 +22,10 @@ spec:
         app.kubernetes.io/name: redis-operator
     spec:
       containers:
-      - image: ghcr.io/freshworks/redis-operator:v3.3.2@sha256:1ea859add694dc9da5800e8fbcb05e300ebdf3d49ced6815d53d019380d20973
+      - env:
+        - name: OPERATOR_GROUP_ID
+          value: redis-operator
+        image: ghcr.io/gadgetmg/redis-operator:3.3.3@sha256:e59a02576e4752e5779baec85188d53ac77c6f55391fb9e0bfd227cea54878b6
         imagePullPolicy: IfNotPresent
         name: redis-operator
         ports:

--- a/manifests/production/redis-operator/monitoring.coreos.com_v1_servicemonitor_redis-operator.yaml
+++ b/manifests/production/redis-operator/monitoring.coreos.com_v1_servicemonitor_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:

--- a/manifests/production/redis-operator/rbac.authorization.k8s.io_v1_clusterrole_redis-operator.yaml
+++ b/manifests/production/redis-operator/rbac.authorization.k8s.io_v1_clusterrole_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
 rules:
 - apiGroups:

--- a/manifests/production/redis-operator/rbac.authorization.k8s.io_v1_clusterrolebinding_redis-operator.yaml
+++ b/manifests/production/redis-operator/rbac.authorization.k8s.io_v1_clusterrolebinding_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/production/redis-operator/v1_namespace_redis-operator.yaml
+++ b/manifests/production/redis-operator/v1_namespace_redis-operator.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator

--- a/manifests/production/redis-operator/v1_service_redis-operator.yaml
+++ b/manifests/production/redis-operator/v1_service_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:

--- a/manifests/production/redis-operator/v1_serviceaccount_redis-operator.yaml
+++ b/manifests/production/redis-operator/v1_serviceaccount_redis-operator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator

--- a/manifests/test/harbor/databases.spotahome.com_v1_redisfailover_harbor.yaml
+++ b/manifests/test/harbor/databases.spotahome.com_v1_redisfailover_harbor.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/instance: harbor
     app.kubernetes.io/name: redis
     app.kubernetes.io/part-of: harbor
+    redis-failover.freshworks.com/operator-group: redis-operator
   name: harbor
   namespace: harbor
 spec:

--- a/manifests/test/redis-operator/apps_v1_deployment_redis-operator.yaml
+++ b/manifests/test/redis-operator/apps_v1_deployment_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:
@@ -22,7 +22,10 @@ spec:
         app.kubernetes.io/name: redis-operator
     spec:
       containers:
-      - image: ghcr.io/freshworks/redis-operator:v3.3.2@sha256:1ea859add694dc9da5800e8fbcb05e300ebdf3d49ced6815d53d019380d20973
+      - env:
+        - name: OPERATOR_GROUP_ID
+          value: redis-operator
+        image: ghcr.io/gadgetmg/redis-operator:3.3.3@sha256:e59a02576e4752e5779baec85188d53ac77c6f55391fb9e0bfd227cea54878b6
         imagePullPolicy: IfNotPresent
         name: redis-operator
         ports:

--- a/manifests/test/redis-operator/monitoring.coreos.com_v1_servicemonitor_redis-operator.yaml
+++ b/manifests/test/redis-operator/monitoring.coreos.com_v1_servicemonitor_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:

--- a/manifests/test/redis-operator/rbac.authorization.k8s.io_v1_clusterrole_redis-operator.yaml
+++ b/manifests/test/redis-operator/rbac.authorization.k8s.io_v1_clusterrole_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
 rules:
 - apiGroups:

--- a/manifests/test/redis-operator/rbac.authorization.k8s.io_v1_clusterrolebinding_redis-operator.yaml
+++ b/manifests/test/redis-operator/rbac.authorization.k8s.io_v1_clusterrolebinding_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/test/redis-operator/v1_namespace_redis-operator.yaml
+++ b/manifests/test/redis-operator/v1_namespace_redis-operator.yaml
@@ -1,4 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator

--- a/manifests/test/redis-operator/v1_service_redis-operator.yaml
+++ b/manifests/test/redis-operator/v1_service_redis-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator
 spec:

--- a/manifests/test/redis-operator/v1_serviceaccount_redis-operator.yaml
+++ b/manifests/test/redis-operator/v1_serviceaccount_redis-operator.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: redis-operator
     app.kubernetes.io/name: redis-operator
-    app.kubernetes.io/version: 1.3.0
+    app.kubernetes.io/version: 3.3.3
   name: redis-operator
   namespace: redis-operator

--- a/shared/components/restricted-pod-security/transformer.yaml
+++ b/shared/components/restricted-pod-security/transformer.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.kubernetes.io/function: |
       container:
-        image: gcr.io/kpt-fn/starlark:v0.5.0
+        image: ghcr.io/kptdev/krm-functions-catalog/starlark:v0.5.5
     config.kubernetes.io/local-config: "true"
 data:
   source: |

--- a/tests/bats/redis-operator/resources/redisfailover.yaml
+++ b/tests/bats/redis-operator/resources/redisfailover.yaml
@@ -3,6 +3,8 @@ apiVersion: databases.spotahome.com/v1
 kind: RedisFailover
 metadata:
   name: test-redis
+  labels:
+    redis-failover.freshworks.com/operator-group: redis-operator
 spec:
   auth:
     secretPath: redis-auth


### PR DESCRIPTION
Replaces `freshworks/redis-operator` image with custom version to workaround organization permission change.