### PR TITLE
fix: Use k8s-digester to add digests for helm inflations, etc

### DIFF
--- a/apps/argocd/base/kustomization.yaml
+++ b/apps/argocd/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: argo-cd
@@ -40,6 +41,8 @@ helmCharts:
     redis:
       image:
         repository: ghcr.io/valkey-io/valkey
+        # renovate: datasource=docker depName=ghcr.io/valkey-io/valkey
+        tag: 9.0.0-alpine3.22@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b
     server:
       httproute:
         enabled: true
@@ -391,11 +394,3 @@ helmCharts:
             send:
             - app-sync-status-unknown
             when: app.status.sync.status == 'Unknown'
-
-images:
-- name: quay.io/argoproj/argocd
-  newTag: v3.4.1@sha256:097c922fb910e6bb0278b0e26382f88de4fa5c966564111bddd334051b0e63d7
-- name: ghcr.io/dexidp/dex
-  newTag: v2.45.1-distroless@sha256:8bfd667b384c2a2555c355c58c167e11127d2ea1a3711f1c246e4d7c5528eb2a
-- name: ghcr.io/valkey-io/valkey
-  newTag: 9.0.0-alpine3.22@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b

--- a/apps/cert-manager/base/kustomization.yaml
+++ b/apps/cert-manager/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: cert-manager
@@ -35,11 +36,3 @@ helmCharts:
       replicaCount: 1
       podDisruptionBudget:
         enabled: true
-
-images:
-- name: quay.io/jetstack/cert-manager-cainjector
-  newTag: v1.20.2@sha256:6f5a644135887b2aa7d5cc145072fa56421560e3586ff1f184358022d490f4e1
-- name: quay.io/jetstack/cert-manager-controller
-  newTag: v1.20.2@sha256:fe0623d7d04a382c888f03343a3a2da716e0d96ad3d5d790c0ebcbcb2a4329a5
-- name: quay.io/jetstack/cert-manager-webhook
-  newTag: v1.20.2@sha256:baf651128b9f05c426cbd5e60e2036bf382c99ca270f49d0757d6f7d2452f4e5

--- a/apps/cloudflare-gateway/base/kustomization.yaml
+++ b/apps/cloudflare-gateway/base/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
 - https://github.com/pl4nty/cloudflare-kubernetes-gateway/config/default?ref=v0.8.2
 - https://github.com/pl4nty/cloudflare-kubernetes-gateway/config/prometheus?ref=v0.8.2
 
+components:
+- ../../../shared/components/k8s-digester
+
 patches:
 - patch: | # Privilege namespace
     apiVersion: v1
@@ -31,7 +34,3 @@ patches:
             - name: GATEWAY_IMAGE
               # renovate: datasource=docker depName=cloudflare/cloudflared
               value: docker.io/cloudflare/cloudflared:2025.11.1@sha256:89ee50efb1e9cb2ae30281a8a404fed95eb8f02f0a972617526f8c5b417acae2
-
-images:
-- name: ghcr.io/pl4nty/cloudflare-kubernetes-gateway
-  newTag: v0.8.2@sha256:ccaad4b868952b2a4872bdc90eb8b3bc75b79b472954b953e776460d2206f198

--- a/apps/cnpg/base/kustomization.yaml
+++ b/apps/cnpg/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: cloudnative-pg
@@ -17,9 +18,3 @@ helmCharts:
   version: 0.28.1
   valuesInline:
     replicaCount: 1
-
-images:
-- name: ghcr.io/cloudnative-pg/plugin-barman-cloud
-  newTag: v0.12.0@sha256:0b9c428123313d93efbec26bdef85e91f2130a7bd8e382a767de12b3938f6271
-- name: ghcr.io/cloudnative-pg/cloudnative-pg
-  newTag: 1.29.1@sha256:0dfff19ba7b52ca25851a1010028b6940fff2e233290465af1cfb08a5f3f4661

--- a/apps/crossplane/base/kustomization.yaml
+++ b/apps/crossplane/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: crossplane
@@ -35,7 +36,3 @@ helmCharts:
         type: RuntimeDefault
     provider:
       defaultActivations: []
-
-images:
-- name: ghcr.io/crossplane/crossplane
-  newTag: v2.2.1@sha256:3a680497a08851ed75b60d48bdefa63a1bd1eed69dee81eaded50959904775ad

--- a/apps/csi-driver-smb/base/kustomization.yaml
+++ b/apps/csi-driver-smb/base/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: kube-system
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: csi-driver-smb
@@ -13,15 +14,3 @@ helmCharts:
   releaseName: csi-driver-smb
   namespace: kube-system
   version: 1.20.1
-
-images:
-- name: registry.k8s.io/sig-storage/livenessprobe
-  newTag: v2.18.0@sha256:c4cc074199c045dd73ab85f28897e2a32f4d6f38ffdba4f3b13b8007ccbd3570
-- name: registry.k8s.io/sig-storage/csi-node-driver-registrar
-  newTag: v2.16.0@sha256:ab482308a4921e28a6df09a16ab99a457e9af9641ff44fb1be1a690d07ce8b70
-- name: registry.k8s.io/sig-storage/smbplugin
-  newTag: v1.20.1@sha256:e5b148629c4b22554b60bc428195c15c992ee3fc24a45aff9873edd0a401a9e8
-- name: registry.k8s.io/sig-storage/csi-provisioner
-  newTag: v6.2.0@sha256:6be9f63ca4caa6c46aae55aa372500949d8a21473d72f819da1f746076b32d4e
-- name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: v2.1.0@sha256:589e525cddef6d768e68da1f0bc9ffd0a24bf3add3dd010648eb7189976fde79

--- a/apps/csi-snapshotter/base/kustomization.yaml
+++ b/apps/csi-snapshotter/base/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
 - https://github.com/kubernetes-csi/external-snapshotter/client/config/crd?ref=v8.5.0
 - https://github.com/kubernetes-csi/external-snapshotter/deploy/kubernetes/snapshot-controller?ref=v8.5.0
 
-images:
-- name: registry.k8s.io/sig-storage/snapshot-controller
-  newTag: v8.5.0@sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8
+components:
+- ../../../shared/components/k8s-digester

--- a/apps/external-dns/production/kustomization.yaml
+++ b/apps/external-dns/production/kustomization.yaml
@@ -8,10 +8,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
-
-images:
-- name: docker.io/renanqts/external-dns-openwrt-webhook
-  newTag: v0.1.0@sha256:a356eb7ead234dc673108c30de761ed9f9542709fc0d8cc8332f81dd53a74d63
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: external-dns
@@ -31,7 +28,8 @@ helmCharts:
       webhook:
         image:
           repository: docker.io/renanqts/external-dns-openwrt-webhook
-          tag: latest
+          # renovate: datasource=docker depName=renanqts/external-dns-openwrt-webhook
+          tag: v0.1.0@sha256:a356eb7ead234dc673108c30de761ed9f9542709fc0d8cc8332f81dd53a74d63
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false

--- a/apps/external-secrets/base/kustomization.yaml
+++ b/apps/external-secrets/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: external-secrets
@@ -26,7 +27,3 @@ helmCharts:
           issuerRef:
             kind: ClusterIssuer
             name: cluster-ca
-
-images:
-- name: ghcr.io/external-secrets/external-secrets
-  newTag: v2.4.1@sha256:9440a40b394791a5e93f3f7e1b33399ecbdc0e38273de1d69ed83fe12936fc09

--- a/apps/headlamp/base/kustomization.yaml
+++ b/apps/headlamp/base/kustomization.yaml
@@ -13,16 +13,6 @@ components:
 - ../../../shared/components/strip-helm-labels
 - ../../../shared/components/restricted-pod-security
 
-images:
-- name: ghcr.io/magohl/external-secrets-operator-headlamp-plugin
-  newTag: 0.1.0-beta7@sha256:7a48e51b90337ff3b5bf74e326047fc5886257b316be7c5a17e707dcce4cbd64
-- name: ghcr.io/buttahtoast/headlamp-plugins/kubevirt
-  newTag: v0.0.1-beta6@sha256:e2c9c498517b18d2d1ae47949be6a7e74453b049b6173095e3e350e301ba1222
-- name: ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager
-  newTag: v0.1.0@sha256:d7d0321a90c0347e2e4f9f7e362ecaa10a36592cc5ac8fd1514df11c476b43fe
-- name: ghcr.io/headlamp-k8s/headlamp
-  newTag: v0.42.0@sha256:c9754bae1d799220da0547e51ceee234f6e66ebadc138518ca73e33ecd331e59
-
 helmCharts:
 - name: headlamp
   repo: https://kubernetes-sigs.github.io/headlamp
@@ -46,7 +36,8 @@ helmCharts:
       mountPath: /headlamp/plugins
     initContainers:
     - name: install-cert-manager-plugin
-      image: ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager
+      # renovate: datasource=docker depName=ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager
+      image: ghcr.io/headlamp-k8s/headlamp-plugin-cert-manager:v0.1.0@sha256:d7d0321a90c0347e2e4f9f7e362ecaa10a36592cc5ac8fd1514df11c476b43fe
       command: ["/bin/sh", "-c", "cp -r /plugins/* /headlamp/plugins/"]
       volumeMounts:
       - name: plugins-dir
@@ -55,7 +46,8 @@ helmCharts:
         runAsUser: 100
         runAsGroup: 101
     - name: install-kubevirt-plugin
-      image: ghcr.io/buttahtoast/headlamp-plugins/kubevirt
+      # renovate: datasource=docker depName=ghcr.io/buttahtoast/headlamp-plugins/kubevirt
+      image: ghcr.io/buttahtoast/headlamp-plugins/kubevirt:v0.0.1-beta6@sha256:e2c9c498517b18d2d1ae47949be6a7e74453b049b6173095e3e350e301ba1222
       command: ["/bin/sh", "-c", "cp -r /plugins/* /headlamp/plugins/"]
       volumeMounts:
       - name: plugins-dir
@@ -65,7 +57,8 @@ helmCharts:
         runAsGroup: 101
     - name: install-external-secrets-operator-plugin
       command: ["/bin/sh", "-c", "cp -r /plugins/* /headlamp/plugins/"]
-      image: ghcr.io/magohl/external-secrets-operator-headlamp-plugin
+      # renovate: datasource=docker depName=ghcr.io/magohl/external-secrets-operator-headlamp-plugin
+      image: ghcr.io/magohl/external-secrets-operator-headlamp-plugin:0.1.0-beta7@sha256:7a48e51b90337ff3b5bf74e326047fc5886257b316be7c5a17e707dcce4cbd64
       volumeMounts:
       - name: plugins-dir
         mountPath: /headlamp/plugins

--- a/apps/idp/base/keycloak/kustomization.yaml
+++ b/apps/idp/base/keycloak/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 
 components:
 - ../../../../shared/components/strip-helm-labels
+- ../../../../shared/components/k8s-digester
 
 helmCharts:
 - name: keycloak

--- a/apps/idp/base/kustomization.yaml
+++ b/apps/idp/base/kustomization.yaml
@@ -21,5 +21,3 @@ components:
 images:
 - name: ghcr.io/cloudnative-pg/postgresql
   newTag: 18.3-standard-trixie@sha256:9f9f53c9e07e5b2924945e6eaeb9168f7e856786d221839866ac85ccd703b3ba
-- name: quay.io/keycloak/keycloak
-  newTag: 26.6.1-0@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8

--- a/apps/kyverno/base/kustomization.yaml
+++ b/apps/kyverno/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 components:
 - ../../../shared/components/strip-helm-labels
 - ../../../shared/components/kapp-noop-helm-hooks
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: kyverno
@@ -39,17 +40,3 @@ helmCharts:
       replicas: 1
       serviceMonitor:
         enabled: true
-
-images:
-- name: ghcr.io/kyverno/kyverno
-  newTag: v1.16.3@sha256:c2d71785b67357617aaddb308e7115f88261b9f36c4774bb8194a2464ec3d601
-- name: ghcr.io/kyverno/kyvernopre
-  newTag: v1.18.0@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7
-- name: ghcr.io/kyverno/background-controller
-  newTag: v1.16.3@sha256:0a8f9369e889117a605ecb527bdc07f3bd25a9183e588a92442246824b2262b5
-- name: ghcr.io/kyverno/cleanup-controller
-  newTag: v1.18.0@sha256:a2a060b731f1ea54de2295b886c600d65af032fec18096a816424acfe8dec7d2
-- name: ghcr.io/kyverno/reports-controller
-  newTag: v1.18.0@sha256:0090bf10eabae091ceb48c38fb894580b63c4e76e40137b7972f5895f0402110
-- name: ghcr.io/kyverno/kyverno-cli
-  newTag: v1.18.0@sha256:1e99a199adb36cedddf5c3e2fc24a150e26cf2e18b9e8dfe505a3c862647a4eb

--- a/apps/mariadb-operator/base/kustomization.yaml
+++ b/apps/mariadb-operator/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 patches:
 - patch: |
@@ -65,7 +66,3 @@ helmCharts:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-
-images:
-- name: ghcr.io/mariadb-operator/mariadb-operator
-  newTag: 26.3.0@sha256:5ef5a5d35173b9be603970e7a1625100a0538004ddca984508df2c08c4fd5c72

--- a/apps/monitoring/base/kustomization.yaml
+++ b/apps/monitoring/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 components:
 - ../../../shared/components/strip-helm-labels
 - ../../../shared/components/crd-configurations
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: prometheus-operator-crds
@@ -141,19 +142,7 @@ helmCharts:
         window: 3m
 
 images:
-- name: quay.io/prometheus/node-exporter
-  newTag: v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
-- name: docker.io/grafana/grafana
-  newTag: 13.0.1@sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a
-- name: quay.io/kiwigrid/k8s-sidecar
-  newTag: 2.7.1@sha256:2670f251f80d990635460c0116497a9cc3202069e8826f1a279af300ecd9f75e
-- name: quay.io/prometheus/alertmanager
-  newTag: v0.32.1@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286
-- name: quay.io/prometheus-operator/prometheus-operator
-  newTag: v0.91.0@sha256:9e53e13139218aca79ee000172de73355e9174ef2904585bfad9497fc71aae2d
 - name: quay.io/prometheus/prometheus
   newTag: v3.11.3@sha256:c0b857aead0d5793aa566adb8f49a9983d6f6031652098759d521a330cfa050f
-- name: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  newTag: v2.18.0@sha256:1545919b72e3ae035454fc054131e8d0f14b42ef6fc5b2ad5c751cafa6b2130e
-- name: registry.k8s.io/prometheus-adapter/prometheus-adapter
-  newTag: v0.12.0@sha256:932eae60e2bcf9c4660d6442da066ef1a79b4ea7cc232c61c7303069216ca006
+- name: quay.io/prometheus/alertmanager
+  newTag: v0.32.1@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286

--- a/apps/redis-operator/base/kustomization.yaml
+++ b/apps/redis-operator/base/kustomization.yaml
@@ -6,20 +6,11 @@ namespace: redis-operator
 
 resources:
 - namespace.yaml
-- https://github.com/freshworks/redis-operator/manifests/kustomize/overlays/full?ref=v3.3.3
+- redis-operator
 
 components:
 - ../../../shared/components/restricted-pod-security
-
-images:
-- name: ghcr.io/freshworks/redis-operator
-  newName: ghcr.io/gadgetmg/redis-operator
-  newTag: 3.3.3@sha256:e59a02576e4752e5779baec85188d53ac77c6f55391fb9e0bfd227cea54878b6
-
-labels:
-- includeSelectors: false
-  pairs:
-    app.kubernetes.io/version: 3.3.3
+- ../../../shared/components/k8s-digester
 
 patches:
 - path: patches/operator-group-id.yaml

--- a/apps/redis-operator/base/redis-operator/kustomization.yaml
+++ b/apps/redis-operator/base/redis-operator/kustomization.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/freshworks/redis-operator/manifests/kustomize/overlays/full?ref=v3.3.3
+
+images:
+- name: ghcr.io/freshworks/redis-operator
+  newName: ghcr.io/gadgetmg/redis-operator
+  newTag: 3.3.3@sha256:e59a02576e4752e5779baec85188d53ac77c6f55391fb9e0bfd227cea54878b6
+
+labels:
+- includeSelectors: false
+  pairs:
+    app.kubernetes.io/version: 3.3.3

--- a/apps/sealed-secrets/base/kustomization.yaml
+++ b/apps/sealed-secrets/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: sealed-secrets
@@ -17,7 +18,3 @@ helmCharts:
     image:
       registry: ghcr.io
       repository: bitnami-labs/sealed-secrets-controller
-
-images:
-- name: ghcr.io/bitnami-labs/sealed-secrets-controller
-  newTag: 0.36.6@sha256:3cf5db7d1722710de8b9216c821cad2ff52e0d284843b205a86ce99af21b05a3

--- a/apps/trust-manager/base/kustomization.yaml
+++ b/apps/trust-manager/base/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: trust-manager
@@ -20,9 +21,3 @@ helmCharts:
             enabled: true
     podDisruptionBudget:
       enabled: true
-
-images:
-- name: quay.io/jetstack/trust-manager
-  newTag: v0.22.1@sha256:23e2ab0711d77c3d25a7297d480883e8d037659db88dcdc0dab788a08a1b2097
-- name: quay.io/jetstack/trust-pkg-debian-bookworm
-  newTag: 20230311-deb12u1.2@sha256:f9a6f14926da740c2831a738393f061b22594ec5d47ff55f68b1f59cfb9bf543

--- a/apps/velero/base/kustomization.yaml
+++ b/apps/velero/base/kustomization.yaml
@@ -6,13 +6,12 @@ resources:
 - namespace.yaml
 
 images:
-- name: docker.io/velero/velero
-  newTag: v1.18.0@sha256:e4d1e79be2ee1d51056734ada5e51c78a29b924e4d055cd28e0b4103ae2268ad
 - name: docker.io/velero/velero-plugin-for-aws
   newTag: v1.14.0@sha256:7e82f717f44e89671212e0dfce7e061321c386ea84a33bca64a671670ca6c278
 
 components:
 - ../../../shared/components/strip-helm-labels
+- ../../../shared/components/k8s-digester
 
 helmCharts:
 - name: velero

--- a/manifests/production/argocd/apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/production/argocd/apps_v1_deployment_argocd-dex-server.yaml
@@ -71,7 +71,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.45.1-distroless@sha256:8bfd667b384c2a2555c355c58c167e11127d2ea1a3711f1c246e4d7c5528eb2a
+        image: ghcr.io/dexidp/dex:v2.45.1@sha256:8499afd690c437f52301efd2b05b2455da5bd2dfc20332cd697dc9937f808462
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/production/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
+++ b/manifests/production/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-startupapicheck:v1.20.2
+        image: quay.io/jetstack/cert-manager-startupapicheck:v1.20.2@sha256:4e2a69b4a0cc9627905bbeecf720f95d5153ca39cacdab923d2748e73556792b
         imagePullPolicy: IfNotPresent
         name: cert-manager-startupapicheck
         securityContext:

--- a/manifests/production/csi-driver-smb/apps_v1_daemonset_csi-smb-node-win.yaml
+++ b/manifests/production/csi-driver-smb/apps_v1_daemonset_csi-smb-node-win.yaml
@@ -67,7 +67,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1@sha256:e5b148629c4b22554b60bc428195c15c992ee3fc24a45aff9873edd0a401a9e8
+        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1-windows-hp@sha256:d66147764fd5936aad08581ca8f7c0e7054cf550971cc956f39d61b11c79f0ca
         imagePullPolicy: IfNotPresent
         name: smb
         resources:
@@ -87,7 +87,7 @@ spec:
         - -c
         - New-Item -ItemType Directory -Path C:\var\lib\kubelet\plugins\smb.csi.k8s.io\
           -Force
-        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1@sha256:e5b148629c4b22554b60bc428195c15c992ee3fc24a45aff9873edd0a401a9e8
+        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1-windows-hp@sha256:d66147764fd5936aad08581ca8f7c0e7054cf550971cc956f39d61b11c79f0ca
         imagePullPolicy: IfNotPresent
         name: init
         securityContext:

--- a/manifests/production/csi-driver-smb/apps_v1_deployment_csi-smb-controller.yaml
+++ b/manifests/production/csi-driver-smb/apps_v1_deployment_csi-smb-controller.yaml
@@ -32,7 +32,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0@sha256:6be9f63ca4caa6c46aae55aa372500949d8a21473d72f819da1f746076b32d4e
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1@sha256:d992c36d4ddd6dfa37c81b487e5a673920e1360e2977eb779051df8da1c5787d
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources:

--- a/manifests/production/csi-snapshotter/apps_v1_deployment_snapshot-controller.yaml
+++ b/manifests/production/csi-snapshotter/apps_v1_deployment_snapshot-controller.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: registry.k8s.io/sig-storage/snapshot-controller:v8.5.0@sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8
+        image: registry.k8s.io/sig-storage/snapshot-controller:v8.4.0@sha256:b845f4bbc34d70bd84e92f8021f47704df1de3dbabbd8289969651360b39d605
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       serviceAccountName: snapshot-controller

--- a/manifests/production/external-dns/apps_v1_deployment_openwrt-external-dns.yaml
+++ b/manifests/production/external-dns/apps_v1_deployment_openwrt-external-dns.yaml
@@ -34,7 +34,7 @@ spec:
         - --policy=upsert-only
         - --registry=txt
         - --provider=webhook
-        image: registry.k8s.io/external-dns/external-dns:v0.21.0
+        image: registry.k8s.io/external-dns/external-dns:v0.21.0@sha256:f53faaf71cb270d1ca9dce6ea0c94bfebf1a18696263487f0fbc74b9bf2bd7ff
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2

--- a/manifests/production/headlamp/apps_v1_deployment_headlamp.yaml
+++ b/manifests/production/headlamp/apps_v1_deployment_headlamp.yaml
@@ -39,7 +39,7 @@ spec:
           value: email,profile
         - name: OIDC_CALLBACK_URL
           value: https://headlamp.seigra.net/oidc-callback
-        image: ghcr.io/headlamp-k8s/headlamp:v0.42.0@sha256:c9754bae1d799220da0547e51ceee234f6e66ebadc138518ca73e33ecd331e59
+        image: ghcr.io/headlamp-k8s/headlamp:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/production/idp/apps_v1_statefulset_keycloak.yaml
+++ b/manifests/production/idp/apps_v1_statefulset_keycloak.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: password
               name: keycloak-db-app
-        image: quay.io/keycloak/keycloak:26.6.1-0@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+        image: quay.io/keycloak/keycloak:26.6.1@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
@@ -134,7 +134,7 @@ spec:
         - sh
         - -c
         - cp -r /opt/keycloak/lib/quarkus/* /shared-quarkus/
-        image: quay.io/keycloak/keycloak:26.6.1-0@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+        image: quay.io/keycloak/keycloak:26.6.1@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
         imagePullPolicy: Always
         name: copy-quarkus-lib
         resources: {}

--- a/manifests/production/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
+++ b/manifests/production/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
@@ -96,7 +96,7 @@ spec:
           value: /.sigstore
         - name: KYVERNO_DEPLOYMENT
           value: kyverno-admission-controller
-        image: ghcr.io/kyverno/kyverno:v1.16.3@sha256:c2d71785b67357617aaddb308e7115f88261b9f36c4774bb8194a2464ec3d601
+        image: ghcr.io/kyverno/kyverno:v1.16.2@sha256:b0c123d62a1b8e21da707450ef44c4616832434f919d1cd19cfdbe2836277699
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2
@@ -180,7 +180,7 @@ spec:
           value: kyverno-admission-controller
         - name: KYVERNO_SVC
           value: kyverno-svc
-        image: ghcr.io/kyverno/kyvernopre:v1.18.0@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7
+        image: ghcr.io/kyverno/kyvernopre:v1.16.2@sha256:ba3a31b25a9e1c6f993d7555158396d87790445ddc785426c249e8320b94b02a
         imagePullPolicy: IfNotPresent
         name: kyverno-pre
         resources:

--- a/manifests/production/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
+++ b/manifests/production/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/kyverno/background-controller:v1.16.3@sha256:0a8f9369e889117a605ecb527bdc07f3bd25a9183e588a92442246824b2262b5
+        image: ghcr.io/kyverno/background-controller:v1.16.2@sha256:736c5da855863a3b15ee0e272f5b9e72c3c1b2f221f8345664354f57a5dc0f25
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/production/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
+++ b/manifests/production/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KYVERNO_SVC
           value: kyverno-cleanup-controller
-        image: ghcr.io/kyverno/cleanup-controller:v1.18.0@sha256:a2a060b731f1ea54de2295b886c600d65af032fec18096a816424acfe8dec7d2
+        image: ghcr.io/kyverno/cleanup-controller:v1.16.2@sha256:1bf6d0501d7f16aa5d36821f907287d8653564c642866c4b597f2e6abc527390
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2

--- a/manifests/production/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
+++ b/manifests/production/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.namespace
         - name: TUF_ROOT
           value: /.sigstore
-        image: ghcr.io/kyverno/reports-controller:v1.18.0@sha256:0090bf10eabae091ceb48c38fb894580b63c4e76e40137b7972f5895f0402110
+        image: ghcr.io/kyverno/reports-controller:v1.16.2@sha256:88d0dfc245a689e9bf3e258159b539f3a1b1a5a89f82b6a07c12762527bb7793
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/production/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
+++ b/manifests/production/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
@@ -52,7 +52,7 @@ spec:
         - policyexceptions.policies.kyverno.io
         - --resource
         - validatingpolicies.policies.kyverno.io
-        image: ghcr.io/kyverno/kyverno-cli:v1.18.0@sha256:1e99a199adb36cedddf5c3e2fc24a150e26cf2e18b9e8dfe505a3c862647a4eb
+        image: ghcr.io/kyverno/kyverno-cli:v1.16.2@sha256:f1a4dd586f118ca24d1fb768b8791a506231748d41cb490dfff04b66b2738079
         imagePullPolicy: IfNotPresent
         name: kubectl
         resources:

--- a/manifests/production/kyverno/batch_v1_job_kyverno-rm-mutatingwhconfig.yaml
+++ b/manifests/production/kyverno/batch_v1_job_kyverno-rm-mutatingwhconfig.yaml
@@ -26,7 +26,7 @@ spec:
         - mutatingwebhookconfiguration
         - -l
         - webhook.kyverno.io/managed-by=kyverno
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/production/kyverno/batch_v1_job_kyverno-rm-validatingwhconfig.yaml
+++ b/manifests/production/kyverno/batch_v1_job_kyverno-rm-validatingwhconfig.yaml
@@ -26,7 +26,7 @@ spec:
         - validatingwebhookconfiguration
         - -l
         - webhook.kyverno.io/managed-by=kyverno
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/production/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
+++ b/manifests/production/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
@@ -29,7 +29,7 @@ spec:
         - -l
         - app.kubernetes.io/part-of=kyverno
         - --replicas=0
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/production/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
+++ b/manifests/production/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-svc-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
+++ b/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; curl -skf https://kyverno-cleanup-controller.kyverno:443/health/liveness
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-cleanup-controller-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
+++ b/manifests/production/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate https://kyverno-cleanup-controller.kyverno:443/health/readiness
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/production/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
+++ b/manifests/production/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-reports-controller-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/production/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/production/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
@@ -53,7 +53,7 @@ spec:
         env:
         - name: HOST_IP
           value: 0.0.0.0
-        image: quay.io/prometheus/node-exporter:v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
+        image: quay.io/prometheus/node-exporter:v1.11.1-distroless@sha256:6112664fd761bb964d8a2d3d0119d6c8402618a89edbb3a43c8f7b4090fb53c9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/production/monitoring/monitoring_apps_v1_deployment_grafana.yaml
+++ b/manifests/production/monitoring/monitoring_apps_v1_deployment_grafana.yaml
@@ -55,7 +55,7 @@ spec:
           value: http://localhost:3000/api/admin/provisioning/dashboards/reload
         - name: REQ_METHOD
           value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:2670f251f80d990635460c0116497a9cc3202069e8826f1a279af300ecd9f75e
+        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:5bc0c5634d4aae468e27e98bf1aae4f45d82fcbfd73baf4a9d3fb0699c62f83d
         imagePullPolicy: IfNotPresent
         name: grafana-sc-dashboard
         securityContext:
@@ -93,7 +93,7 @@ spec:
           value: http://localhost:3000/api/admin/provisioning/datasources/reload
         - name: REQ_METHOD
           value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:2670f251f80d990635460c0116497a9cc3202069e8826f1a279af300ecd9f75e
+        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:5bc0c5634d4aae468e27e98bf1aae4f45d82fcbfd73baf4a9d3fb0699c62f83d
         imagePullPolicy: IfNotPresent
         name: grafana-sc-datasources
         securityContext:

--- a/manifests/production/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/production/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -49,7 +49,7 @@ spec:
         env:
         - name: GOGC
           value: "30"
-        image: quay.io/prometheus-operator/prometheus-operator:v0.91.0@sha256:9e53e13139218aca79ee000172de73355e9174ef2904585bfad9497fc71aae2d
+        image: quay.io/prometheus-operator/prometheus-operator:v0.90.1@sha256:52a6a92d915ea2fa94314748d99db7a94922e3fe63274f6182fc033b9126b573
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/production/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/production/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -31,7 +31,7 @@ spec:
         - --host=prometheus-operator,prometheus-operator.monitoring.svc
         - --namespace=monitoring
         - --secret-name=k8s-admission
-        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2
+        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2@sha256:e133b64c08377a107298ac3352504bd3cd21f13282bc2aac099a88a7888b3f54
         imagePullPolicy: IfNotPresent
         name: create
         resources: {}

--- a/manifests/production/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/production/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -32,7 +32,7 @@ spec:
         - --namespace=monitoring
         - --secret-name=k8s-admission
         - --patch-failure-policy=
-        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2
+        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2@sha256:e133b64c08377a107298ac3352504bd3cd21f13282bc2aac099a88a7888b3f54
         imagePullPolicy: IfNotPresent
         name: patch
         resources: {}

--- a/manifests/production/redis-operator/v1_namespace_redis-operator.yaml
+++ b/manifests/production/redis-operator/v1_namespace_redis-operator.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    app.kubernetes.io/version: 3.3.3
   name: redis-operator

--- a/manifests/production/trust-manager/apps_v1_deployment_trust-manager.yaml
+++ b/manifests/production/trust-manager/apps_v1_deployment_trust-manager.yaml
@@ -71,7 +71,7 @@ spec:
         - /copyandmaybepause
         - /debian-package
         - /packages
-        image: quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.2@sha256:f9a6f14926da740c2831a738393f061b22594ec5d47ff55f68b1f59cfb9bf543
+        image: quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.6@sha256:06fe54a72d1ddb268d64a022d0d9f031aa93204136a8e9a131913fc968a3889d
         imagePullPolicy: IfNotPresent
         name: cert-manager-package-debian
         securityContext:

--- a/manifests/test/argocd/apps_v1_deployment_argocd-dex-server.yaml
+++ b/manifests/test/argocd/apps_v1_deployment_argocd-dex-server.yaml
@@ -71,7 +71,7 @@ spec:
               key: dexserver.disable.tls
               name: argocd-cmd-params-cm
               optional: true
-        image: ghcr.io/dexidp/dex:v2.45.1-distroless@sha256:8bfd667b384c2a2555c355c58c167e11127d2ea1a3711f1c246e4d7c5528eb2a
+        image: ghcr.io/dexidp/dex:v2.45.1@sha256:8499afd690c437f52301efd2b05b2455da5bd2dfc20332cd697dc9937f808462
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/test/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
+++ b/manifests/test/cert-manager/cert-manager_batch_v1_job_cert-manager-startupapicheck.yaml
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-startupapicheck:v1.20.2
+        image: quay.io/jetstack/cert-manager-startupapicheck:v1.20.2@sha256:4e2a69b4a0cc9627905bbeecf720f95d5153ca39cacdab923d2748e73556792b
         imagePullPolicy: IfNotPresent
         name: cert-manager-startupapicheck
         securityContext:

--- a/manifests/test/csi-driver-smb/apps_v1_daemonset_csi-smb-node-win.yaml
+++ b/manifests/test/csi-driver-smb/apps_v1_daemonset_csi-smb-node-win.yaml
@@ -67,7 +67,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1@sha256:e5b148629c4b22554b60bc428195c15c992ee3fc24a45aff9873edd0a401a9e8
+        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1-windows-hp@sha256:d66147764fd5936aad08581ca8f7c0e7054cf550971cc956f39d61b11c79f0ca
         imagePullPolicy: IfNotPresent
         name: smb
         resources:
@@ -87,7 +87,7 @@ spec:
         - -c
         - New-Item -ItemType Directory -Path C:\var\lib\kubelet\plugins\smb.csi.k8s.io\
           -Force
-        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1@sha256:e5b148629c4b22554b60bc428195c15c992ee3fc24a45aff9873edd0a401a9e8
+        image: registry.k8s.io/sig-storage/smbplugin:v1.20.1-windows-hp@sha256:d66147764fd5936aad08581ca8f7c0e7054cf550971cc956f39d61b11c79f0ca
         imagePullPolicy: IfNotPresent
         name: init
         securityContext:

--- a/manifests/test/csi-driver-smb/apps_v1_deployment_csi-smb-controller.yaml
+++ b/manifests/test/csi-driver-smb/apps_v1_deployment_csi-smb-controller.yaml
@@ -32,7 +32,7 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
-        image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0@sha256:6be9f63ca4caa6c46aae55aa372500949d8a21473d72f819da1f746076b32d4e
+        image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1@sha256:d992c36d4ddd6dfa37c81b487e5a673920e1360e2977eb779051df8da1c5787d
         imagePullPolicy: IfNotPresent
         name: csi-provisioner
         resources:

--- a/manifests/test/csi-snapshotter/apps_v1_deployment_snapshot-controller.yaml
+++ b/manifests/test/csi-snapshotter/apps_v1_deployment_snapshot-controller.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - --v=5
         - --leader-election=true
-        image: registry.k8s.io/sig-storage/snapshot-controller:v8.5.0@sha256:74ca61ab13e978f03cf0f336a607281d15f04cda0a38a881306365473b28a3d8
+        image: registry.k8s.io/sig-storage/snapshot-controller:v8.4.0@sha256:b845f4bbc34d70bd84e92f8021f47704df1de3dbabbd8289969651360b39d605
         imagePullPolicy: IfNotPresent
         name: snapshot-controller
       serviceAccountName: snapshot-controller

--- a/manifests/test/headlamp/apps_v1_deployment_headlamp.yaml
+++ b/manifests/test/headlamp/apps_v1_deployment_headlamp.yaml
@@ -40,7 +40,7 @@ spec:
           value: email,profile
         - name: OIDC_CALLBACK_URL
           value: https://headlamp.10.5.0.55.nip.io/oidc-callback
-        image: ghcr.io/headlamp-k8s/headlamp:v0.42.0@sha256:c9754bae1d799220da0547e51ceee234f6e66ebadc138518ca73e33ecd331e59
+        image: ghcr.io/headlamp-k8s/headlamp:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/manifests/test/idp/apps_v1_statefulset_keycloak.yaml
+++ b/manifests/test/idp/apps_v1_statefulset_keycloak.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: password
               name: keycloak-db-app
-        image: quay.io/keycloak/keycloak:26.6.1-0@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+        image: quay.io/keycloak/keycloak:26.6.1@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3
@@ -134,7 +134,7 @@ spec:
         - sh
         - -c
         - cp -r /opt/keycloak/lib/quarkus/* /shared-quarkus/
-        image: quay.io/keycloak/keycloak:26.6.1-0@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
+        image: quay.io/keycloak/keycloak:26.6.1@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8
         imagePullPolicy: Always
         name: copy-quarkus-lib
         resources: {}

--- a/manifests/test/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
+++ b/manifests/test/kyverno/apps_v1_deployment_kyverno-admission-controller.yaml
@@ -96,7 +96,7 @@ spec:
           value: /.sigstore
         - name: KYVERNO_DEPLOYMENT
           value: kyverno-admission-controller
-        image: ghcr.io/kyverno/kyverno:v1.16.3@sha256:c2d71785b67357617aaddb308e7115f88261b9f36c4774bb8194a2464ec3d601
+        image: ghcr.io/kyverno/kyverno:v1.16.2@sha256:b0c123d62a1b8e21da707450ef44c4616832434f919d1cd19cfdbe2836277699
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2
@@ -180,7 +180,7 @@ spec:
           value: kyverno-admission-controller
         - name: KYVERNO_SVC
           value: kyverno-svc
-        image: ghcr.io/kyverno/kyvernopre:v1.18.0@sha256:60b53ebf646f788e6e5d312f9cbf267d7537ec14afec68bde2e1dad55c552cc7
+        image: ghcr.io/kyverno/kyvernopre:v1.16.2@sha256:ba3a31b25a9e1c6f993d7555158396d87790445ddc785426c249e8320b94b02a
         imagePullPolicy: IfNotPresent
         name: kyverno-pre
         resources:

--- a/manifests/test/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
+++ b/manifests/test/kyverno/apps_v1_deployment_kyverno-background-controller.yaml
@@ -71,7 +71,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/kyverno/background-controller:v1.16.3@sha256:0a8f9369e889117a605ecb527bdc07f3bd25a9183e588a92442246824b2262b5
+        image: ghcr.io/kyverno/background-controller:v1.16.2@sha256:736c5da855863a3b15ee0e272f5b9e72c3c1b2f221f8345664354f57a5dc0f25
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/test/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
+++ b/manifests/test/kyverno/apps_v1_deployment_kyverno-cleanup-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KYVERNO_SVC
           value: kyverno-cleanup-controller
-        image: ghcr.io/kyverno/cleanup-controller:v1.18.0@sha256:a2a060b731f1ea54de2295b886c600d65af032fec18096a816424acfe8dec7d2
+        image: ghcr.io/kyverno/cleanup-controller:v1.16.2@sha256:1bf6d0501d7f16aa5d36821f907287d8653564c642866c4b597f2e6abc527390
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2

--- a/manifests/test/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
+++ b/manifests/test/kyverno/apps_v1_deployment_kyverno-reports-controller.yaml
@@ -85,7 +85,7 @@ spec:
               fieldPath: metadata.namespace
         - name: TUF_ROOT
           value: /.sigstore
-        image: ghcr.io/kyverno/reports-controller:v1.18.0@sha256:0090bf10eabae091ceb48c38fb894580b63c4e76e40137b7972f5895f0402110
+        image: ghcr.io/kyverno/reports-controller:v1.16.2@sha256:88d0dfc245a689e9bf3e258159b539f3a1b1a5a89f82b6a07c12762527bb7793
         imagePullPolicy: IfNotPresent
         name: controller
         ports:

--- a/manifests/test/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
+++ b/manifests/test/kyverno/batch_v1_job_kyverno-migrate-resources.yaml
@@ -52,7 +52,7 @@ spec:
         - policyexceptions.policies.kyverno.io
         - --resource
         - validatingpolicies.policies.kyverno.io
-        image: ghcr.io/kyverno/kyverno-cli:v1.18.0@sha256:1e99a199adb36cedddf5c3e2fc24a150e26cf2e18b9e8dfe505a3c862647a4eb
+        image: ghcr.io/kyverno/kyverno-cli:v1.16.2@sha256:f1a4dd586f118ca24d1fb768b8791a506231748d41cb490dfff04b66b2738079
         imagePullPolicy: IfNotPresent
         name: kubectl
         resources:

--- a/manifests/test/kyverno/batch_v1_job_kyverno-rm-mutatingwhconfig.yaml
+++ b/manifests/test/kyverno/batch_v1_job_kyverno-rm-mutatingwhconfig.yaml
@@ -26,7 +26,7 @@ spec:
         - mutatingwebhookconfiguration
         - -l
         - webhook.kyverno.io/managed-by=kyverno
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/test/kyverno/batch_v1_job_kyverno-rm-validatingwhconfig.yaml
+++ b/manifests/test/kyverno/batch_v1_job_kyverno-rm-validatingwhconfig.yaml
@@ -26,7 +26,7 @@ spec:
         - validatingwebhookconfiguration
         - -l
         - webhook.kyverno.io/managed-by=kyverno
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/test/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
+++ b/manifests/test/kyverno/batch_v1_job_kyverno-scale-to-zero.yaml
@@ -29,7 +29,7 @@ spec:
         - -l
         - app.kubernetes.io/part-of=kyverno
         - --replicas=0
-        image: registry.k8s.io/kubectl:v1.32.7
+        image: registry.k8s.io/kubectl:v1.32.7@sha256:3c526815897478b22becbb5d2eadf0e0c021b41248400b8bcc8c6f32132442d2
         imagePullPolicy: null
         name: kubectl
         resources:

--- a/manifests/test/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
+++ b/manifests/test/kyverno/v1_pod_kyverno-admission-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-svc-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
+++ b/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-liveness.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; curl -skf https://kyverno-cleanup-controller.kyverno:443/health/liveness
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
+++ b/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-cleanup-controller-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
+++ b/manifests/test/kyverno/v1_pod_kyverno-cleanup-controller-readiness.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate https://kyverno-cleanup-controller.kyverno:443/health/readiness
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/test/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
+++ b/manifests/test/kyverno/v1_pod_kyverno-reports-controller-metrics.yaml
@@ -17,7 +17,7 @@ spec:
     - /bin/sh
     - -c
     - sleep 20 ; wget -O- -S --no-check-certificate http://kyverno-reports-controller-metrics.kyverno:8000/metrics
-    image: curlimages/curl:8.10.1
+    image: curlimages/curl:8.10.1@sha256:d9b4541e214bcd85196d6e92e2753ac6d0ea699f0af5741f8c6cccbfcf00ef4b
     imagePullPolicy: IfNotPresent
     name: test
     resources:

--- a/manifests/test/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
+++ b/manifests/test/monitoring/kube-system_apps_v1_daemonset_node-exporter.yaml
@@ -53,7 +53,7 @@ spec:
         env:
         - name: HOST_IP
           value: 0.0.0.0
-        image: quay.io/prometheus/node-exporter:v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
+        image: quay.io/prometheus/node-exporter:v1.11.1-distroless@sha256:6112664fd761bb964d8a2d3d0119d6c8402618a89edbb3a43c8f7b4090fb53c9
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/test/monitoring/monitoring_apps_v1_deployment_grafana.yaml
+++ b/manifests/test/monitoring/monitoring_apps_v1_deployment_grafana.yaml
@@ -55,7 +55,7 @@ spec:
           value: http://localhost:3000/api/admin/provisioning/dashboards/reload
         - name: REQ_METHOD
           value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:2670f251f80d990635460c0116497a9cc3202069e8826f1a279af300ecd9f75e
+        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:5bc0c5634d4aae468e27e98bf1aae4f45d82fcbfd73baf4a9d3fb0699c62f83d
         imagePullPolicy: IfNotPresent
         name: grafana-sc-dashboard
         securityContext:
@@ -93,7 +93,7 @@ spec:
           value: http://localhost:3000/api/admin/provisioning/datasources/reload
         - name: REQ_METHOD
           value: POST
-        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:2670f251f80d990635460c0116497a9cc3202069e8826f1a279af300ecd9f75e
+        image: quay.io/kiwigrid/k8s-sidecar:2.7.1@sha256:5bc0c5634d4aae468e27e98bf1aae4f45d82fcbfd73baf4a9d3fb0699c62f83d
         imagePullPolicy: IfNotPresent
         name: grafana-sc-datasources
         securityContext:

--- a/manifests/test/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
+++ b/manifests/test/monitoring/monitoring_apps_v1_deployment_prometheus-operator.yaml
@@ -49,7 +49,7 @@ spec:
         env:
         - name: GOGC
           value: "30"
-        image: quay.io/prometheus-operator/prometheus-operator:v0.91.0@sha256:9e53e13139218aca79ee000172de73355e9174ef2904585bfad9497fc71aae2d
+        image: quay.io/prometheus-operator/prometheus-operator:v0.90.1@sha256:52a6a92d915ea2fa94314748d99db7a94922e3fe63274f6182fc033b9126b573
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/manifests/test/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
+++ b/manifests/test/monitoring/monitoring_batch_v1_job_k8s-admission-create.yaml
@@ -31,7 +31,7 @@ spec:
         - --host=prometheus-operator,prometheus-operator.monitoring.svc
         - --namespace=monitoring
         - --secret-name=k8s-admission
-        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2
+        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2@sha256:e133b64c08377a107298ac3352504bd3cd21f13282bc2aac099a88a7888b3f54
         imagePullPolicy: IfNotPresent
         name: create
         resources: {}

--- a/manifests/test/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
+++ b/manifests/test/monitoring/monitoring_batch_v1_job_k8s-admission-patch.yaml
@@ -32,7 +32,7 @@ spec:
         - --namespace=monitoring
         - --secret-name=k8s-admission
         - --patch-failure-policy=
-        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2
+        image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.2@sha256:e133b64c08377a107298ac3352504bd3cd21f13282bc2aac099a88a7888b3f54
         imagePullPolicy: IfNotPresent
         name: patch
         resources: {}

--- a/manifests/test/redis-operator/v1_namespace_redis-operator.yaml
+++ b/manifests/test/redis-operator/v1_namespace_redis-operator.yaml
@@ -1,6 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    app.kubernetes.io/version: 3.3.3
   name: redis-operator

--- a/manifests/test/trust-manager/apps_v1_deployment_trust-manager.yaml
+++ b/manifests/test/trust-manager/apps_v1_deployment_trust-manager.yaml
@@ -71,7 +71,7 @@ spec:
         - /copyandmaybepause
         - /debian-package
         - /packages
-        image: quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.2@sha256:f9a6f14926da740c2831a738393f061b22594ec5d47ff55f68b1f59cfb9bf543
+        image: quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.6@sha256:06fe54a72d1ddb268d64a022d0d9f031aa93204136a8e9a131913fc968a3889d
         imagePullPolicy: IfNotPresent
         name: cert-manager-package-debian
         securityContext:

--- a/shared/components/k8s-digester/kustomization.yaml
+++ b/shared/components/k8s-digester/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+- transformer.yaml

--- a/shared/components/k8s-digester/transformer.yaml
+++ b/shared/components/k8s-digester/transformer.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-digester
+  annotations:
+    config.kubernetes.io/function: |
+      container:
+        image: ghcr.io/google/k8s-digester:v0.1.16
+        network: true
+    config.kubernetes.io/local-config: "true"

--- a/taskfiles/kustomize.yaml
+++ b/taskfiles/kustomize.yaml
@@ -6,7 +6,7 @@ env:
   KUBERNETES_VERSION: v1.36.0
 
 vars:
-  BUILD_ARGS: --load-restrictor LoadRestrictionsNone --enable-helm --enable-alpha-plugins --helm-kube-version {{.KUBERNETES_VERSION}}
+  BUILD_ARGS: --load-restrictor LoadRestrictionsNone --enable-helm --enable-alpha-plugins --network --helm-kube-version {{.KUBERNETES_VERSION}}
   PROJECT_ROOT: '{{.TASKFILE_DIR | dir}}'
   MANIFESTS_DIR: '{{.PROJECT_ROOT}}/manifests'
   CRDS_DIR: '{{.PROJECT_ROOT}}/crds'

--- a/tests/bats/cert-manager/tests.bats
+++ b/tests/bats/cert-manager/tests.bats
@@ -10,6 +10,7 @@ setup_file() {
     -f crds/test \
     -f manifests/test/cert-manager \
     -f manifests/test/clusterissuers
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/cnpg/tests.bats
+++ b/tests/bats/cnpg/tests.bats
@@ -10,6 +10,7 @@ setup_file() {
     -f crds/test \
     -f manifests/test/cert-manager \
     -f manifests/test/cnpg
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/external-secrets/tests.bats
+++ b/tests/bats/external-secrets/tests.bats
@@ -11,6 +11,7 @@ setup_file() {
     -f manifests/test/cert-manager \
     -f manifests/test/external-secrets \
     -f manifests/test/clusterissuers
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/kyverno/tests.bats
+++ b/tests/bats/kyverno/tests.bats
@@ -9,6 +9,7 @@ setup_file() {
   kapp deploy -y -a setup \
     -f crds/test \
     -f manifests/test/kyverno
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/mariadb-operator/tests.bats
+++ b/tests/bats/mariadb-operator/tests.bats
@@ -9,6 +9,7 @@ setup_file() {
   kapp deploy -y -a setup \
     -f crds/test \
     -f manifests/test/mariadb-operator
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/redis-operator/tests.bats
+++ b/tests/bats/redis-operator/tests.bats
@@ -9,6 +9,7 @@ setup_file() {
   kapp deploy -y -a setup \
     -f crds/test \
     -f manifests/test/redis-operator
+  sleep 5
 }
 
 teardown_file() {

--- a/tests/bats/trust-manager/tests.bats
+++ b/tests/bats/trust-manager/tests.bats
@@ -11,6 +11,7 @@ setup_file() {
     -f manifests/test/cert-manager \
     -f manifests/test/clusterissuers \
     -f manifests/test/trust-manager
+  sleep 5
 }
 
 teardown_file() {


### PR DESCRIPTION
This fixes problems introduced when an upstream helm chart or kustomization is updated, but the container images and their digests are updated in a different commit by Renovate.